### PR TITLE
Make Version.page_uuid non-optional

### DIFF
--- a/src/services/web-monitoring-db.ts
+++ b/src/services/web-monitoring-db.ts
@@ -3,7 +3,7 @@ const defaultApiUrl = 'https://web-monitoring-db-staging.herokuapp.com/';
 
 export interface Version {
     uuid: string;
-    page_uuid?: string;
+    page_uuid: string;
     capture_time: Date;
     uri: string;
     version_hash: string;


### PR DESCRIPTION
As noticed by @danielballan in reviewing #48 here: https://github.com/edgi-govdata-archiving/web-monitoring-ui/pull/48#discussion_r118367836
Not sure why I had marked this as optional; I can't think of a case where it shouldn't be present.