### PR TITLE
Use a DB URL that actually works in `.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-WEB_MONITORING_DB_URL=http://web-monitoring-db.dev
+WEB_MONITORING_DB_URL=https://web-monitoring-db-staging.herokuapp.com
 
 # These will be removed once a login form is added
 WEB_MONITORING_DB_USER=user@example.com


### PR DESCRIPTION
People are (totally reasonably) blindly copying `.env.example` → `.env` and hitting issues because they don't have a DB server running locally at `web-monitoring-db.dev`. (See #52, for example.) We should have the configuration in the example `.env` file be something that works and is not confusing :)