### PR TITLE
HOTFIX: Upgrade Node.js to 6.11.x (security)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6.11.x
+    version: 6.11.1
 dependencies:
   override:
     - yarn

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6.5.0
+    version: 6.11.x
 dependencies:
   override:
     - yarn

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": "6.5.0"
+    "node": "6.11.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": "6.11.x"
+    "node": "6.11.1"
   }
 }


### PR DESCRIPTION
Node.js recently released a new version to fix a several vulnerabilities, including a potential DOS attack. This will get us to a new version with that patch. See https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/

(We should probably update to Node.js 8 sometime soon, but not going to do that all of a sudden here)