### PR TITLE
Suppress browser's native auth dialog

### DIFF
--- a/src/services/web-monitoring-db.ts
+++ b/src/services/web-monitoring-db.ts
@@ -79,7 +79,8 @@ export default class WebMonitoringDb {
             }),
             headers: new Headers({
                 'Accept': 'application/json',
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest'
             }),
             method: 'POST',
             mode: 'cors',
@@ -151,7 +152,8 @@ export default class WebMonitoringDb {
             body: JSON.stringify(annotation),
             credentials: 'include',
             headers: new Headers({
-                Authorization: this.authHeader()
+                'Authorization': this.authHeader(),
+                'X-Requested-With': 'XMLHttpRequest'
             }),
             method: 'POST',
             mode: 'cors',
@@ -207,7 +209,8 @@ export default class WebMonitoringDb {
                 headers: new Headers({
                     'Accept': 'application/json',
                     'Authorization': this.authHeader(),
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
                 }),
                 method: refresh ? 'POST' : 'GET',
                 mode: 'cors',


### PR DESCRIPTION
The browser will occasionally show its own HTTP auth dialog instead of ours when an authenticated XHR/fetch request fails, which can be really confusing for a user. On the server side, we already suppress the headers that trigger this when a request identifies itself as an XHR, so just make sure we always identify ourselves as an XHR.