### PR TITLE
WIP: Add experimental version timeline to ChangeView

### DIFF
--- a/src/components/change-view.jsx
+++ b/src/components/change-view.jsx
@@ -7,6 +7,7 @@ import AnnotationForm from './annotation-form';
 import DiffView from './diff-view';
 import SelectDiffType from './select-diff-type';
 import SelectVersion from './select-version';
+import VersionTimelineSelector from './version-timeline-selector';
 
 const collapsedViewStorage = 'WebMonitoring.ChangeView.collapsedView';
 
@@ -26,14 +27,15 @@ const collapsedViewStorage = 'WebMonitoring.ChangeView.collapsedView';
  */
 export default class ChangeView extends React.Component {
     constructor (props) {
-        super (props);
+        super(props);
 
         this.state = {
           a: null,
           b: null,
           change: null,
           collapsedView: true,
-          diffType: undefined
+          diffType: undefined,
+          showTimeline: false,
         };
 
         // TODO: unify this default state logic with componentWillReceiveProps
@@ -55,6 +57,7 @@ export default class ChangeView extends React.Component {
         this.handleVersionBChange = this.handleVersionBChange.bind(this);
         this.handleDiffTypeChange = this.handleDiffTypeChange.bind(this);
         this._toggleCollapsedView = this._toggleCollapsedView.bind(this);
+        this._toggleTimeline = this._toggleTimeline.bind(this);
         this._annotateChange = this._annotateChange.bind(this);
         this._updateAnnotation = this._updateAnnotation.bind(this);
     }
@@ -104,9 +107,22 @@ export default class ChangeView extends React.Component {
           return (<div></div>);
         }
 
+        let timeline;
+        if (this.state.showTimeline) {
+            timeline = (
+                <VersionTimelineSelector
+                    versions={page.versions}
+                    onSelect={this._updateChange.bind(this)}
+                    selectedFromVersion={this.state.a}
+                    selectedToVersion={this.state.b}
+                />
+            );
+        }
+
         return (
             <div className="change-view">
                 {this.renderVersionSelector(page)}
+                {timeline}
                 {this.renderSubmission()}
                 <DiffView page={page} diffType={this.state.diffType} a={this.state.a} b={this.state.b} />
             </div>
@@ -116,18 +132,21 @@ export default class ChangeView extends React.Component {
     renderVersionSelector (page) {
         return (
             <form className="version-selector">
-                <label className="version-selector__item form-group">
+                <label className="version-selector__item">
                     <span>Comparison:</span>
                     <SelectDiffType value={this.state.diffType} onChange={this.handleDiffTypeChange} />
                 </label>
-                <label className="version-selector__item form-group">
+                <label className="version-selector__item">
                     <span>From:</span>
                     <SelectVersion versions={page.versions} value={this.state.a} onChange={this.handleVersionAChange} />
                 </label>
-                <label className="version-selector__item form-group">
+                <label className="version-selector__item">
                     <span>To:</span>
                     <SelectVersion versions={page.versions} value={this.state.b} onChange={this.handleVersionBChange} />
                 </label>
+                <button className="btn btn-link" onClick={this._toggleTimeline}>
+                    {this.state.showTimeline ? 'Hide' : 'Show'} Timeline
+                </button>
             </form>
         );
     }
@@ -171,6 +190,11 @@ export default class ChangeView extends React.Component {
     _toggleCollapsedView (event) {
         event.preventDefault();
         this.setState(previousState => ({collapsedView: !previousState.collapsedView}));
+    }
+
+    _toggleTimeline (event) {
+        event.preventDefault();
+        this.setState(previousState => ({showTimeline: !previousState.showTimeline}));
     }
 
     _updateAnnotation (newAnnotation) {

--- a/src/components/version-timeline-selector.jsx
+++ b/src/components/version-timeline-selector.jsx
@@ -1,0 +1,122 @@
+import React from 'react';
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    month: 'long',
+    second: 'numeric',
+    year: 'numeric'
+});
+
+// sizes are in ems
+const minSize = 1.2;
+const maxSize = 3.5;
+
+/**
+ * @typedef {Object} VersionTimelineSelectorProps
+ * @property {Version[]} versions
+ * @property {Version[]} selectedFromVersion
+ * @property {Version[]} selectedToVersion
+ * @property {Version[]} onSelect Callback when a new range is selected.
+ *   Signature: `(Versions[]) => void`
+ */
+
+/**
+ * Display a timeline of versions, where the user can select a version range.
+ * @class VersionTimelineSelector
+ * @extends {React.PureComponent}
+ */
+export default class VersionTimelineSelector extends React.PureComponent {
+    constructor (props) {
+        super(props);
+        this._selectVersion = this._selectVersion.bind(this);
+        this._renderVersion = this._renderVersion.bind(this);
+
+        this.state = {
+            selecting: false,
+            selectionBuffer: null
+        };
+    }
+
+    render () {
+        return (
+            <div className="version-timeline-selector">
+                <ol className="version-timeline-selector__list">
+                    {this.props.versions.map(this._renderVersion)}
+                </ol>
+            </div>
+        );
+    }
+
+    /**
+     * Render a single version on the timeline
+     * @param {Version} version
+     * @returns {HTMLElement}
+     */
+    _renderVersion (version) {
+        let size = (maxSize + minSize) / 2;
+        if (version.source_type === 'versionista') {
+            const sizeFactor = version.source_metadata.diff_length / 30000;
+            const sizeRange = maxSize - minSize;
+            size = Math.min(maxSize, minSize + sizeRange * sizeFactor);
+        }
+
+        const style = {width: `${size}em`, height: `${size}em`};
+        const classes = [];
+
+        const fullDate = dateFormatter.format(version.capture_time);
+        let title = `${fullDate} (${version.source_type})`;
+        if (version.source_metadata.errorCode) {
+            classes.push('error-version');
+            title = `${title}\n${version.source_metadata.errorCode} Error`;
+            style.width = style.height = '';
+        }
+
+        if (this.state.selecting) {
+            if (version === this.state.selectionBuffer) {
+                classes.push('provisionally-selected');
+            }
+        }
+        else {
+            if (version === this.props.selectedFromVersion || version === this.props.selectedToVersion) {
+                classes.push('selected');
+            }
+        }
+
+        return (
+            <li
+                style={style}
+                title={title}
+                className={classes.join(' ')}
+                data-version={version.uuid}
+                key={version.uuid}
+                onClick={this._selectVersion}
+                tabIndex={0}
+            >
+                <span className="version-timeline-selector__label">
+                    {version.capture_time.getMonth() + 1}/{version.capture_time.getDate()}
+                </span>
+                {/* TODO: other metadata */}
+            </li>
+        );
+    }
+
+    _selectVersion (event) {
+        event.preventDefault();
+        const uuid = event.currentTarget.dataset.version;
+        const version = this.props.versions.find(v => v.uuid === uuid);
+
+        if (this.state.selecting) {
+            const selection = [this.state.selectionBuffer, version]
+                .sort((a, b) => a.capture_time - b.capture_time);
+            this.setState({selecting: false, selectionBuffer: null});
+            if (this.props.onSelect) {
+                this.props.onSelect(...selection);
+            }
+        }
+        else {
+            this.setState({selecting: true, selectionBuffer: version});
+        }
+    }
+}

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -209,6 +209,7 @@ ins {
 
 .version-selector {
     display: flex;
+    margin: 0.5em 0 0.1em;
 }
 
 .version-selector__item {
@@ -219,4 +220,76 @@ ins {
 .version-selector__item > span {
     font-weight: bold;
     margin-right: 0.5em;
+}
+
+.version-selector > button {
+    padding: 0;
+    margin-bottom: 5px;
+}
+
+.version-timeline-selector {}
+
+.version-timeline-selector__list {
+    align-items: center;
+    display: flex;
+    list-style-type: none;
+    margin: 0 0 1em;
+    padding: 0 0 1em;
+    flex-direction: row-reverse;
+    overflow: auto;
+    position: relative;
+}
+
+.version-timeline-selector__list::before {
+    background: #aaa;
+    content: '';
+    height: 3px;
+    left: 0;
+    position: absolute;
+    right: 1em;
+    top: calc(50% - 2px - 0.5em);
+}
+
+.version-timeline-selector__list > li {
+    background: white;
+    border-radius: 50%;
+    width: 1.5em;
+    height: 1.5em;
+    display: block;
+    position: relative;
+    flex: 0 0 auto;
+    border: 2px solid #aaa;
+    margin: 1em;
+}
+
+.version-timeline-selector__list > li.error-version {
+    border: none;
+    width: 1.5em;
+    height: 1.5em;
+}
+
+.version-timeline-selector__list > li.error-version::before {
+    content: '!';
+    position: absolute;
+    left: 0;
+    right: 0;
+    text-align: center;
+    line-height: 1.5em;
+    color: #999;
+}
+
+.version-timeline-selector__list > li.selected {
+    border: 3px solid #66aaff;
+}
+
+.version-timeline-selector__list > li.provisionally-selected {
+    border: 3px dashed #66aaff;
+}
+
+.version-timeline-selector__label {
+    color: #666;
+    position: absolute;
+    bottom: -1.6em;
+    left: -1em;
+    right: -1em;text-align: center;
 }


### PR DESCRIPTION
**Do Not Merge: this is for feedback and conceptual review**

The timeline shows all of a Page's versions in chronological order, with each item sized by how much changed between that version and the preceding version (when that info is available -- only for Versionista data right now). Versions that are flagged as errors have an '!' instead of a circle.

![screen shot 2017-07-27 at 4 57 21 pm](https://user-images.githubusercontent.com/74178/28696792-c3254584-72ec-11e7-9ac3-c4ebcaf39a7d.png)

There are likely a number of other useful things we could visualize in this timeline, like whether a version is attached to any changes with annotations, whether a version has been marked as significant, and so on.

For now, this is just an experiment and the implementation needs more than the 2 hours of work here. If people like it, it could replace the dropdowns for selecting versions.