### PR TITLE
Add environment var to force SSL for all requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,6 @@ GOOGLE_TASK_SHEET_ID=123xyz
 # API key for access to Google sheets
 # https://developers.google.com/api-client-library/javascript/start/start-js#setup
 GOOGLE_SHEETS_API_KEY=123xyz
+
+# Redirect all HTTP requests to https (you probably want this off in development)
+# FORCE_SSL=true

--- a/server/app.js
+++ b/server/app.js
@@ -7,14 +7,25 @@ const sheetData = require('./sheet-data');
 const config = require('./configuration');
 
 const serverPort = process.env.PORT || 3001;
+const filterArray = [
+    'WEB_MONITORING_DB_URL'
+];
+
+if (process.env.FORCE_SSL && process.env.FORCE_SSL.toLowerCase() === 'true') {
+    app.use((request, response, next) => {
+        if (request.secure || request.headers['x-forwarded-proto'] === 'https') {
+            return next();
+        }
+        response.redirect(
+            301,
+            `https://${request.headers.host}${request.originalUrl}`
+        );
+    });
+}
 
 app.set('views', path.join(__dirname, '../views'));
 app.use(express.static('dist'));
 app.engine('html', require('ejs').renderFile);
-
-const filterArray = [
-    'WEB_MONITORING_DB_URL'
-];
 
 app.get('/api/domains/:username', function(request, response) {
     const username = request.params.username;


### PR DESCRIPTION
I only just realized that the UI does not force all requests to use SSL! This adds a `FORCE_SSL` environment variable that will cause the app to redirect all HTTP requests to HTTPS.