### PR TITLE
HOTFIX: Change imports for babel

### DIFF
--- a/src/components/annotation-form.jsx
+++ b/src/components/annotation-form.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Version} from '../services/web-monitoring-db';
 
 /**

--- a/src/components/change-view.jsx
+++ b/src/components/change-view.jsx
@@ -1,5 +1,5 @@
-import * as PropTypes from 'prop-types';
-import * as React from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {Link} from 'react-router-dom';
 import {diffTypes} from '../constants/diff-types';
 import WebMonitoringDb from '../services/web-monitoring-db';

--- a/src/components/diff-item.jsx
+++ b/src/components/diff-item.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 /**
  * Display a single deleted/added/unchanged element within a diff

--- a/src/components/diff-view.jsx
+++ b/src/components/diff-view.jsx
@@ -1,5 +1,5 @@
-import * as PropTypes from 'prop-types';
-import * as React from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import WebMonitoringDb from '../services/web-monitoring-db';
 import {diffTypes, changeDiffTypes} from '../constants/diff-types';
 

--- a/src/components/highlighted-text-diff.jsx
+++ b/src/components/highlighted-text-diff.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import DiffItem from './diff-item';
 import List from './list';
 

--- a/src/components/list.jsx
+++ b/src/components/list.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 // Basic list component taken from http://github.com/datatogether/context
 // List accepts an array of data, and an item component. It iterates through the

--- a/src/components/login-form.jsx
+++ b/src/components/login-form.jsx
@@ -1,5 +1,5 @@
-import * as PropTypes from 'prop-types';
-import * as React from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {RouteComponentProps} from 'react-router-dom';
 import WebMonitoringDb from '../services/web-monitoring-db';
 

--- a/src/components/nav-bar.jsx
+++ b/src/components/nav-bar.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Link} from 'react-router-dom';
 
 /**

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -1,5 +1,5 @@
-import * as PropTypes from 'prop-types';
-import * as React from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {Link, RouteComponentProps} from 'react-router-dom';
 import WebMonitoringDb, {Page} from '../services/web-monitoring-db';
 import ChangeView from './change-view';

--- a/src/components/page-list.jsx
+++ b/src/components/page-list.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Link, RouteComponentProps} from 'react-router-dom';
 import {Page} from '../services/web-monitoring-db';
 

--- a/src/components/select-diff-type.jsx
+++ b/src/components/select-diff-type.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {diffTypes} from '../constants/diff-types';
 
 /**

--- a/src/components/select-version.jsx
+++ b/src/components/select-version.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Version} from '../services/web-monitoring-db';
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {

--- a/src/components/side-by-side-rendered-diff.jsx
+++ b/src/components/side-by-side-rendered-diff.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Page} from '../services/web-monitoring-db';
 
 /**

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -1,5 +1,5 @@
-import * as PropTypes from 'prop-types';
-import * as React from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import AriaModal from 'react-aria-modal';
 import {BrowserRouter as Router, Link, Route} from 'react-router-dom';
 import bindComponent from '../scripts/bind-component';

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -1,6 +1,6 @@
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
-import * as AriaModal from 'react-aria-modal';
+import AriaModal from 'react-aria-modal';
 import {BrowserRouter as Router, Link, Route} from 'react-router-dom';
 import bindComponent from '../scripts/bind-component';
 import WebMonitoringApi from '../services/web-monitoring-api';

--- a/src/scripts/bind-component.js
+++ b/src/scripts/bind-component.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 /**
  * Similar to function.bind, but binds props to component types. Returns a

--- a/src/scripts/main.jsx
+++ b/src/scripts/main.jsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import React from 'react';
+import ReactDOM from 'react-dom';
 import WebMonitoringUi from '../components/web-monitoring-ui';
 
 ReactDOM.render(


### PR DESCRIPTION
After dropping Typescript and moving to Babel as our transpiler, errors were cropping up because of how the two interpreted module `import` statements differently. This [article](https://medium.com/@kentcdodds/misunderstanding-es6-modules-upgrading-babel-tears-and-a-solution-ad2d5ab93ce0) explains it way better than I ever could. 

This hotfix makes it so we aren't mixing import styles. It gets rid of console warnings and fixes the login modal.