### PR TITLE
Include change versions in URL

### DIFF
--- a/src/components/change-view.jsx
+++ b/src/components/change-view.jsx
@@ -14,8 +14,11 @@ const collapsedViewStorage = 'WebMonitoring.ChangeView.collapsedView';
 /**
  * @typedef ChangeViewProps
  * @property {Page} page
+ * @property {Version} from
+ * @property {Version} to
  * @property {Object} user
- * @property {Function} _annotateChange
+ * @property {Function} annotateChange
+ * @property {Function} onChangeSelectedVersions
  */
 
 /**
@@ -27,193 +30,189 @@ const collapsedViewStorage = 'WebMonitoring.ChangeView.collapsedView';
  */
 export default class ChangeView extends React.Component {
     constructor (props) {
-        super (props);
+      super (props);
 
-        this.state = {
-          a: null,
-          b: null,
-          change: null,
-          annotation: {},
-          collapsedView: true,
-          diffType: undefined,
-          addingToDictionary: false,
-          addingToImportant: false
-        };
+      this.state = {
+        change: null,
+        annotation: {},
+        collapsedView: true,
+        diffType: undefined,
+        addingToDictionary: false,
+        addingToImportant: false
+      };
 
-        // TODO: unify this default state logic with componentWillReceiveProps
-        const page = this.props.page;
-        if (page.versions && page.versions.length > 1) {
-            this.state.a = page.versions[1];
-            this.state.b = page.versions[0];
-            this.state.diffType = 'SIDE_BY_SIDE_RENDERED';
-        }
+      // TODO: unify this default state logic with componentWillReceiveProps
+      const page = this.props.page;
+      if (page.versions && page.versions.length > 1) {
+        this.state.diffType = 'SIDE_BY_SIDE_RENDERED';
+      }
 
-        if ('sessionStorage' in window) {
-            this.state.collapsedView = sessionStorage.getItem(
-                collapsedViewStorage
-            ) !== 'false';
-        }
+      if ('sessionStorage' in window) {
+        this.state.collapsedView = sessionStorage.getItem(
+          collapsedViewStorage
+        ) !== 'false';
+      }
 
-        this.updateDiff = this.updateDiff.bind(this);
-        this.handleVersionAChange = this.handleVersionAChange.bind(this);
-        this.handleVersionBChange = this.handleVersionBChange.bind(this);
-        this.handleDiffTypeChange = this.handleDiffTypeChange.bind(this);
-        this._toggleCollapsedView = this._toggleCollapsedView.bind(this);
-        this._annotateChange = this._annotateChange.bind(this);
-        this._updateAnnotation = this._updateAnnotation.bind(this);
-        this._markAsSignificant = this._markAsSignificant.bind(this);
-        this._addToDictionary = this._addToDictionary.bind(this);
+      this.updateDiff = this.updateDiff.bind(this);
+      this.handleFromVersionChange = this.handleFromVersionChange.bind(this);
+      this.handleToVersionChange = this.handleToVersionChange.bind(this);
+      this.handleDiffTypeChange = this.handleDiffTypeChange.bind(this);
+      this._toggleCollapsedView = this._toggleCollapsedView.bind(this);
+      this._annotateChange = this._annotateChange.bind(this);
+      this._updateAnnotation = this._updateAnnotation.bind(this);
+      this._markAsSignificant = this._markAsSignificant.bind(this);
+      this._addToDictionary = this._addToDictionary.bind(this);
     }
 
     componentWillMount () {
-        this._updateChange();
+      this._getChange();
     }
 
     componentWillReceiveProps (nextProps) {
-        const nextVersions = nextProps.page.versions;
-        if (nextVersions && nextVersions.length > 1) {
-            this._updateChange(nextVersions[1], nextVersions[0]);
-        }
+      const nextVersions = nextProps.page.versions;
+      if (nextVersions && nextVersions.length > 1) {
+        this._getChange(nextVersions[1], nextVersions[0]);
+      }
     }
 
     componentDidUpdate () {
-        if ('sessionStorage' in window) {
-            sessionStorage.setItem(
-                collapsedViewStorage,
-                this.state.collapsedView.toString()
-            );
-        }
+      if ('sessionStorage' in window) {
+        sessionStorage.setItem(
+          collapsedViewStorage,
+          this.state.collapsedView.toString()
+        );
+      }
     }
 
     updateDiff () {
-        // pass
+      // pass
     }
 
     handleDiffTypeChange (diffType) {
       this.setState({diffType});
       this.updateDiff();
     }
-    handleVersionAChange (version) {
-        this._updateChange(version, null);
-        this.updateDiff();
+    handleFromVersionChange (version) {
+      this._changeSelectedVersions(version, null);
+      this.updateDiff();
     }
-    handleVersionBChange (version) {
-        this._updateChange(null, version);
-        this.updateDiff();
+    handleToVersionChange (version) {
+      this._changeSelectedVersions(null, version);
+      this.updateDiff();
     }
 
     render () {
-        const { page } = this.props;
+      const { page } = this.props;
 
-        if (!page || !page.versions) {
-          // if haz no page, don't render
-          return (<div></div>);
-        }
+      if (!page || !page.versions) {
+        // if haz no page, don't render
+        return (<div></div>);
+      }
 
-        return (
-            <div className="change-view">
-                {this.renderSubmission()}
-                {this.renderVersionSelector(page)}
-                <DiffView page={page} diffType={this.state.diffType} a={this.state.a} b={this.state.b} />
-            </div>
-        );
+      return (
+        <div className="change-view">
+          {this.renderSubmission()}
+          {this.renderVersionSelector(page)}
+          <DiffView page={page} diffType={this.state.diffType} a={this.props.from} b={this.props.to} />
+        </div>
+      );
     }
 
     renderVersionSelector (page) {
-        return (
-            <form className="version-selector">
-                <label className="version-selector__item">
-                    <span>From:</span>
-                    <SelectVersion versions={page.versions} value={this.state.a} onChange={this.handleVersionAChange} />
-                </label>
-                <label className="version-selector__item">
-                    <span>Comparison:</span>
-                    <SelectDiffType value={this.state.diffType} onChange={this.handleDiffTypeChange} />
-                </label>
+      return (
+        <form className="version-selector">
+          <label className="version-selector__item">
+            <span>From:</span>
+            <SelectVersion versions={page.versions} value={this.props.from} onChange={this.handleFromVersionChange} />
+          </label>
+          <label className="version-selector__item">
+            <span>Comparison:</span>
+            <SelectDiffType value={this.state.diffType} onChange={this.handleDiffTypeChange} />
+          </label>
 
-                <label className="version-selector__item">
-                    <span>To:</span>
-                    <SelectVersion versions={page.versions} value={this.state.b} onChange={this.handleVersionBChange} />
-                </label>
-            </form>
-        );
+          <label className="version-selector__item">
+            <span>To:</span>
+            <SelectVersion versions={page.versions} value={this.props.to} onChange={this.handleToVersionChange} />
+          </label>
+        </form>
+      );
     }
 
     // TODO: change-view.jsx is becoming very unwieldy with multiple render methods and custom components.
     // We should extract out some of these renders and the 'markSignificant' and 'addToDictionary' components below.
     renderSubmission () {
-        if (!this.props.user) {
-          return <div>Log in to submit annotations.</div>;
-        }
+      if (!this.props.user) {
+        return <div>Log in to submit annotations.</div>;
+      }
 
-        const annotation = this.state.annotation || {};
+      const annotation = this.state.annotation || {};
 
-        let markSignificant;
-        if (annotation.significance >= 0.5) {
-          markSignificant = <span className="status lnk-action">Significant</span>;
-        }
-        else {
-          markSignificant = (
-            <span className="lnk-action">
-              <i className="fa fa-upload" aria-hidden="true" />
-              <button
-                className="btn btn-link"
-                disabled={this.state.addingToImportant}
-                onClick={this._markAsSignificant}
-              >
-                Add Important Change
-              </button>
-            </span>
-          );
-        }
+      let markSignificant;
+      if (annotation.significance >= 0.5) {
+        markSignificant = <span className="status lnk-action">Significant</span>;
+      }
+      else {
+        markSignificant = (
+          <span className="lnk-action">
+            <i className="fa fa-upload" aria-hidden="true" />
+            <button
+              className="btn btn-link"
+              disabled={this.state.addingToImportant}
+              onClick={this._markAsSignificant}
+            >
+              Add Important Change
+            </button>
+          </span>
+        );
+      }
 
-        let addToDictionary;
-        if (annotation.isDictionary) {
-          addToDictionary = <span className="status">In dictionary</span>;
-        }
-        else {
-          addToDictionary = (
-            <span>
-              <i className="fa fa-database" aria-hidden="true" />
-              <button
-                className="btn btn-link"
-                disabled={this.state.addingToDictionary}
-                onClick={this._addToDictionary}
-              >
-                Add to Dictionary
-              </button>
-            </span>
-          );
-        }
+      let addToDictionary;
+      if (annotation.isDictionary) {
+        addToDictionary = <span className="status">In dictionary</span>;
+      }
+      else {
+        addToDictionary = (
+          <span>
+            <i className="fa fa-database" aria-hidden="true" />
+            <button
+              className="btn btn-link"
+              disabled={this.state.addingToDictionary}
+              onClick={this._addToDictionary}
+            >
+              Add to Dictionary
+            </button>
+          </span>
+        );
+      }
 
-        // Returning array of controls so that we don't have an extraneous containing div
-        return [
-            (
-              <div className="row change-view-actions" key="change-view-actions">
-                  <div className="col-md-6">
-                      <i className="fa fa-toggle-on" aria-hidden="true" />
-                      {/* TODO: should be buttons */}
-                      <a className="lnk-action" href="#" onClick={this._toggleCollapsedView}>Toggle Signifiers</a>
-                      <i className="fa fa-pencil" aria-hidden="true" />
-                      <a className="lnk-action" href="#" onClick={this._annotateChange}>Update Record</a>
-                      <i className="fa fa-list" aria-hidden="true" />
-                      <Link to="/" className="lnk-action">Back to list view</Link>
-                  </div>
-                  <div className="col-md-6 text-right">
-                      {markSignificant}
-                      {addToDictionary}
-                  </div>
-              </div>
-            ),
-            (
-              <AnnotationForm
-                  annotation={annotation}
-                  onChange={this._updateAnnotation}
-                  collapsed={this.state.collapsedView}
-                  key="annotation-form"
-              />
-            )
-        ];
+      // Returning array of controls so that we don't have an extraneous containing div
+      return [
+        (
+          <div className="row change-view-actions" key="change-view-actions">
+            <div className="col-md-6">
+              <i className="fa fa-toggle-on" aria-hidden="true" />
+              {/* TODO: should be buttons */}
+              <a className="lnk-action" href="#" onClick={this._toggleCollapsedView}>Toggle Signifiers</a>
+              <i className="fa fa-pencil" aria-hidden="true" />
+              <a className="lnk-action" href="#" onClick={this._annotateChange}>Update Record</a>
+              <i className="fa fa-list" aria-hidden="true" />
+              <Link to="/" className="lnk-action">Back to list view</Link>
+            </div>
+            <div className="col-md-6 text-right">
+              {markSignificant}
+              {addToDictionary}
+            </div>
+          </div>
+        ),
+        (
+          <AnnotationForm
+            annotation={annotation}
+            onChange={this._updateAnnotation}
+            collapsed={this.state.collapsedView}
+            key="annotation-form"
+          />
+        )
+      ];
     }
 
     _toggleCollapsedView (event) {
@@ -236,8 +235,8 @@ export default class ChangeView extends React.Component {
 
         this.context.localApi.addChangeToImportant(
           this.props.page,
-          this.state.a,
-          this.state.b,
+          this.props.from,
+          this.props.to,
           annotation
         )
           .then(onComplete, onComplete);
@@ -259,8 +258,8 @@ export default class ChangeView extends React.Component {
 
         this.context.localApi.addChangeToDictionary(
           this.props.page,
-          this.state.a,
-          this.state.b,
+          this.props.from,
+          this.props.to,
           annotation
         )
           .then(onComplete, onComplete);
@@ -279,32 +278,37 @@ export default class ChangeView extends React.Component {
     _saveAnnotation (annotation) {
       // TODO: display some indicator that saving is happening/complete
       annotation = annotation || this.state.annotation;
-      const fromVersion = this.state.a.uuid;
-      const toVersion = this.state.b.uuid;
+      const fromVersion = this.props.from.uuid;
+      const toVersion = this.props.to.uuid;
       this.props.annotateChange(fromVersion, toVersion, annotation);
     }
 
-    _updateChange (from, to) {
-        from = from || this.state.a;
-        to = to || this.state.b;
+    _changeSelectedVersions (from, to) {
+      from = from || this.props.from;
+      to = to || this.props.to;
 
-        if (!from || !to || changeMatches(this.state.change, {a: from, b: to})) {
-            return;
-        }
+      if (!from || !to || (this.props.from.uuid === from.uuid && this.props.to === to.uuid)) {
+        return;
+      }
 
-        this.setState({a: from, b: to, annotation: null, change: null});
+      this.props.onChangeSelectedVersions(from, to);
+    }
 
-        this.context.api.getChange(this.props.page.uuid, from.uuid, to.uuid)
-            .then(change => {
-                // only update state.change if what we want is still the same
-                // and we don't already have it
-                if (!changeMatches(change, this.state.change) && changeMatches(change, this.state)) {
-                    this.setState({
-                        annotation: Object.assign({}, change.current_annotation),
-                        change
-                    });
-                }
+    _getChange (from, to) {
+      from = from || this.props.from;
+      to = to || this.props.to;
+
+      this.context.api.getChange(this.props.page.uuid, from.uuid, to.uuid)
+        .then(change => {
+          // only update state.change if what we want is still the same
+          // and we don't already have it
+          if (!changeMatches(change, this.state.change) && changeMatches(change, this.props)) {
+            this.setState({
+              annotation: Object.assign({}, change.current_annotation),
+              change
             });
+          }
+        });
     }
 }
 
@@ -313,11 +317,19 @@ ChangeView.contextTypes = {
     localApi: PropTypes.instanceOf(WebMonitoringApi)
 };
 
-function changeMatches (change, state) {
-    if (!state) { return false; }
-    const uuidFrom = state.a ? state.a.uuid : state.uuid_from;
-    const uuidTo = state.b ? state.b.uuid : state.uuid_to;
-    return change && change.uuid_from === uuidFrom && change.uuid_to === uuidTo;
+/**
+ * Determine whether a change object represents the same change as another
+ * change object or object with `from` and `to` properties.
+ * @private
+ * @param {Change} change
+ * @param {Change|ChangeViewProps} other
+ * @returns {boolean}
+ */
+function changeMatches (change, other) {
+  if (!other) { return false; }
+  const uuidFrom = other.from ? other.from.uuid : other.uuid_from;
+  const uuidTo = other.to ? other.to.uuid : other.uuid_to;
+  return change && change.uuid_from === uuidFrom && change.uuid_to === uuidTo;
 }
 
 function isDisabled (element) {

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -82,8 +82,16 @@ export default class PageDetails extends React.Component {
       <div className="container-fluid container-page-view">
         <div className="row">
           <div className="col-md-9">
-            <h2 className="diff-title">{page.title}</h2>
-            <a className="diff_page_url" href={page.url} target="_blank" rel="noopener">{page.url}</a>
+            <h2 className="page-title">
+              <a
+                className="diff_page_url"
+                href={page.url}
+                target="_blank"
+                rel="noopener"
+              >
+                {page.title}
+              </a>
+            </h2>
           </div>
           <div className="col-md-3">
             {this._renderPager()}

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link, RouteComponentProps } from 'react-router-dom';
-import WebMonitoringDb, { Page } from '../services/web-monitoring-db';
+import {Link, Redirect} from 'react-router-dom';
+import WebMonitoringDb, {Page} from '../services/web-monitoring-db';
 import ChangeView from './change-view';
 
 /**
@@ -22,6 +22,7 @@ export default class PageDetails extends React.Component {
     super(props);
     this.state = { page: null };
     this._annotateChange = this._annotateChange.bind(this);
+    this._navigateToChange = this._navigateToChange.bind(this);
   }
 
   componentWillMount () {
@@ -65,7 +66,7 @@ export default class PageDetails extends React.Component {
    * @param {Object} annotation
    */
   _annotateChange (fromVersion, toVersion, annotation) {
-    this.context.api.annotateChange(this.state.page.uuid, fromVersion, toVersion, annotation);
+      this.context.api.annotateChange(this.state.page.uuid, fromVersion, toVersion, annotation);
   }
 
   render () {
@@ -81,26 +82,14 @@ export default class PageDetails extends React.Component {
       <div className="container-fluid container-page-view">
         <div className="row">
           <div className="col-md-9">
-            <h2 className="page-title">
-              <a
-                className="diff_page_url"
-                href={page.url}
-                target="_blank"
-                rel="noopener"
-              >
-                {page.title}
-              </a>
-            </h2>
+            <h2 className="diff-title">{page.title}</h2>
+            <a className="diff_page_url" href={page.url} target="_blank" rel="noopener">{page.url}</a>
           </div>
           <div className="col-md-3">
             {this._renderPager()}
           </div>
         </div>
-        <ChangeView
-          page={this.state.page}
-          annotateChange={this._annotateChange}
-          user={this.props.user}
-        />
+        {this._renderChange()}
       </div>
     );
   }
@@ -131,6 +120,52 @@ export default class PageDetails extends React.Component {
     );
   }
 
+  /**
+   * When possible, render the appropriate ChangeView. Otherwise:
+   * - Redirect to a URL specifying a valid change (if there wasn't one)
+   * - Render a message indicating no change to render (if there's no
+   *   valid change we could navigate to)
+   * @private
+   * @returns {React.Component}
+   */
+  _renderChange () {
+    const page = this.state.page;
+
+    // TODO: should we show 404 for bad versions? (null vs. undefined here)
+    const versionData = this._versionsToRender();
+    if (!versionData) {
+      let [to, from] = page.versions;
+      from = from || to;
+
+      if (from && to) {
+        return <Redirect to={this._getChangeUrl(from, to)} />;
+      }
+
+      return <div className="error">No saved versions of this page</div>;
+    }
+
+    return (
+      <ChangeView
+        {...versionData}
+        page={this.state.page}
+        annotateChange={this._annotateChange}
+        user={this.props.user}
+        onChangeSelectedVersions={this._navigateToChange}
+      />
+    );
+  }
+
+  // NOTE: returns `null` when specified change is invalid, `undefined` when
+  // no change specified at all. (This is subtle; design could be better.)
+  _versionsToRender () {
+    if (this.props.match.params.change) {
+      const [fromId, toId] = this.props.match.params.change.split('..');
+      const from = this.state.page.versions.find(v => v.uuid === fromId);
+      const to = this.state.page.versions.find(v => v.uuid === toId);
+      return (from && to) ? {from, to} : null;
+    }
+  }
+
   _loadPage (pageId) {
     // TODO: handle the missing `.versions` collection problem better
     const fromList = this.props.pages && this.props.pages.find(
@@ -138,8 +173,19 @@ export default class PageDetails extends React.Component {
 
     Promise.resolve(fromList || this.context.api.getPage(pageId))
       .then((page) => {
-        this.setState({ page });
+          this.setState({page});
       });
+  }
+
+  _getChangeUrl (from, to, page) {
+    const changeId = (from && to) ? `${from.uuid}..${to.uuid}` : '';
+    const pageId = page && page.uuid || this.props.match.params.pageId;
+    return `/page/${pageId}/${changeId}`;
+  }
+
+  _navigateToChange (from, to, page, replace = false) {
+    const url = this._getChangeUrl(from, to, page);
+    this.props.history[replace ? 'replace' : 'push'](url);
   }
 }
 

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -92,7 +92,7 @@ export default class WebMonitoringUi extends React.Component {
                     <div id="application">
                         <NavBar title="EDGI" user={this.state.user} showLogin={this.showLogin} logOut={this.logOut} />
                         <Route exact path="/" render={withData(PageList)} />
-                        <Route path="/page/:pageId" render={withData(PageDetails)} />
+                        <Route path="/page/:pageId/:change?" render={withData(PageDetails)} />
                     </div>
                 </Router>
                 {modal}


### PR DESCRIPTION
Page URLs now look like:

    /page/{id}/{from}..{to}

...which follows a similar scheme as our API (but no `/changes/` in between page ID and change ID). This is kinda important so that specific changes are linkable; people can list them in spreadsheets, chat, reports, etc.

Open to feedback on that URL scheme. Could structure the path differently or even put the version IDs in the querystring.

This affects several components because it removes control of the change to be rendered from `ChangeView` — the from and to versions are now props. This unfortunately made rendering PageDetails a lot more complicated, but also I hope it's easier to see the various cases that can happen there now. It makes it a lot more obvious how poorly we are handling pages with 0 or 1 versions.