### PR TITLE
Add context to changes-only diffs

### DIFF
--- a/src/components/changes-only-diff.jsx
+++ b/src/components/changes-only-diff.jsx
@@ -2,6 +2,11 @@ import React from 'react';
 import DiffItem from './diff-item';
 import List from './list';
 
+// The context for a change should be constrained to this many lines
+const maxContextLines = 3;
+// If the context is only a single line, it should be constrained to this length
+const maxContextLineLength = 300;
+
 /**
  * Display a plaintext diff with additions and removals inline.
  *
@@ -17,9 +22,7 @@ export default class ChangesOnlyDiff extends React.Component {
       return null;
     }
 
-    const changesOnly = this.props.diff.content.diff.filter(currentValue => {
-      return currentValue[0] !== 0;
-    });
+    const changesOnly = this.props.diff.content.diff.map(getContextualDiff);
 
     return (
       <List
@@ -32,28 +35,58 @@ export default class ChangesOnlyDiff extends React.Component {
 }
 
 
-/** TODO: Putting contextual diffs off until after v0
-   * Truncating function to process changes-only diffs.
-   * If `currentValue` is an insertion or deletion we return it as is.
-   * If it's not, we truncate it depending on if changes occured in entries before or after it.
-   * @param {array|Object} currentValue
-   * @param {number} index
-   * @param {diff[]} diffs
-   * @returns {[number, string]}
-   */
-// function getContextualDiff (currentValue, index, diffs) {
-//   let [itemType, itemText] = currentValue;
-//   if (itemType !== 0) return currentValue;
+/**
+ * Trim parts of diff entries where there are no changes to show only a few
+ * lines or characters on the ends adjacent to actual changes.
+ * If `currentValue` is an insertion or deletion we return it as is.
+ * If it's not, we truncate it depending on if changes occured in entries before or after it.
+ * @param {[number, string]} currentValue
+ * @param {number} index
+ * @param {Array.<[number, string]>} diffs
+ * @returns {[number, string]}
+ */
+function getContextualDiff (currentValue, index, diffs) {
+  let [itemType, itemText] = currentValue;
+  if (itemType !== 0) return currentValue;
 
-//   // Naive approach, needs massive improvement
-//   const contextLength = 50;
-//   let strContext = '';
+  // Determine whether there is content that actually needs trimming
+  let lines = itemText.split('\n');
+  const singleLine = lines.length === 1;
+  if (!singleLine && lines.length <= maxContextLines) return currentValue;
 
-//   if (diffs[index - 1] && diffs[index - 1][0] !== 0) {
-//     strContext += `${itemText.substring(0, contextLength)}\n`;
-//   }
-//   if (diffs[index + 1] && diffs[index + 1][0] !== 0) {
-//     strContext += `\n${itemText.substring(itemText.length - contextLength)}`;
-//   }
-//   return [itemType, strContext];
-// }
+  const hasPreviousChange = diffs[index - 1] && diffs[index - 1][0] !== 0;
+  const hasNextChange = diffs[index + 1] && diffs[index + 1][0] !== 0;
+
+  let contextLength = singleLine ? maxContextLineLength : maxContextLines;
+  if (hasPreviousChange && hasNextChange) {
+    contextLength *= 2;
+  }
+  if ((singleLine ? lines[0] : lines).length <= contextLength) {
+    return currentValue;
+  }
+
+  // ...and actually do the trimming
+  let newText = [];
+  if (hasPreviousChange) {
+    if (singleLine) {
+      newText.push(lines[0].slice(0, maxContextLineLength));
+    }
+    else {
+      newText.push(lines.slice(0, maxContextLines).join('\n') + '\n');
+    }
+  }
+
+  // Just divide with an ellipsis for now, could be fancier in the future
+  newText.push('…');
+
+  if (hasNextChange) {
+    if (singleLine) {
+      newText.push(lines[0].slice(-maxContextLineLength));
+    }
+    else {
+      newText.push('\n' + lines.slice(-maxContextLines).join('\n'));
+    }
+  }
+
+  return [itemType, newText.join('')];
+}

--- a/src/components/changes-only-diff.jsx
+++ b/src/components/changes-only-diff.jsx
@@ -72,7 +72,15 @@ function getContextualDiff (currentValue, index, diffs) {
       newText.push(lines[0].slice(0, maxContextLineLength));
     }
     else {
-      newText.push(lines.slice(0, maxContextLines).join('\n') + '\n');
+      const newLines = lines
+        .slice(0, maxContextLines)
+        .map(line => {
+          if (line.length > maxContextLineLength) {
+            return line.slice(0, maxContextLineLength) + '…';
+          }
+          return line;
+        });
+      newText.push(newLines.join('\n') + '\n');
     }
   }
 
@@ -84,7 +92,19 @@ function getContextualDiff (currentValue, index, diffs) {
       newText.push(lines[0].slice(-maxContextLineLength));
     }
     else {
-      newText.push('\n' + lines.slice(-maxContextLines).join('\n'));
+      const newLines = lines
+        .slice(0, maxContextLines)
+        .map((line, index, lines) => {
+          if (line.length > maxContextLineLength) {
+            // If this is the last line preceding a change, trim at the start.
+            if (lines[index + 1] == null) {
+              return '…' + line.slice(-maxContextLineLength);
+            }
+            return line.slice(0, maxContextLineLength) + '…';
+          }
+          return line;
+        });
+      newText.push('\n' + newLines.join('\n'));
     }
   }
 

--- a/src/components/changes-only-diff.jsx
+++ b/src/components/changes-only-diff.jsx
@@ -71,8 +71,9 @@ function getContextualDiff (newDiff, currentValue, index, diff) {
 
   // ...and actually do the trimming
   let newEntries = [];
-  let newText = [];
   if (hasPreviousChange) {
+    const newText = [];
+
     if (singleLine) {
       newText.push(lines[0].slice(0, maxContextLineLength));
     }
@@ -87,14 +88,16 @@ function getContextualDiff (newDiff, currentValue, index, diff) {
         });
       newText.push(newLines.join('\n') + '\n');
     }
+
+    newEntries.push([itemType, newText.join('')]);
   }
-  newEntries.push([itemType, newText.join('')]);
 
   // Just divide with an ellipsis for now, could be fancier in the future
   newEntries.push([itemType, '…']);
 
-  newText = [];
   if (hasNextChange) {
+    const newText = [];
+
     if (singleLine) {
       newText.push(lines[0].slice(-maxContextLineLength));
     }
@@ -113,8 +116,9 @@ function getContextualDiff (newDiff, currentValue, index, diff) {
         });
       newText.push('\n' + newLines.join('\n'));
     }
+
+    newEntries.push([itemType, newText.join('')]);
   }
-  newEntries.push([itemType, newText.join('')]);
 
   return newDiff.concat(newEntries);
 }


### PR DESCRIPTION
This is a pretty simple first cut at adding context to the changes-only text and source code diffs.

Instead of simply removing non-changed diff sections, we keep them if they are shorter than the amount of context we want (3 lines or, if only a single line, 300 characters). If they are longer, we split them into multiple non-changed sections so that we have a diff like:

```js
[
  [1, 'Some text'],                         // text that was added
  [0, 'the \n first \n three lines of \n'], // first 3 lines or 300 characters
  [0, '…'],                                 // a separator
  [0, '\n the \n last \n three lines'],     // final 3 lines/300 characters of context
  [1, 'More added text'],
  // ...etc...
]
```

In the future, we’ll probably want to replace the separator entry with some special object that the UI can render in a more fancy way or even make interactive (to expand/contract the amount of context shown).