### PR TITLE
Add visual HTML diff instead of raw side-by-side versions

### DIFF
--- a/src/components/diff-view.jsx
+++ b/src/components/diff-view.jsx
@@ -63,7 +63,7 @@ export default class DiffView extends React.Component {
     switch (diffType) {
     case diffTypes.SIDE_BY_SIDE_RENDERED.value:
       return (
-        <SideBySideRenderedDiff a={a} b={b} page={this.props.page} />
+        <SideBySideRenderedDiff diff={diff} page={this.props.page} />
       );
     case diffTypes.HIGHLIGHTED_TEXT.value:
       return (

--- a/src/components/diff-view.jsx
+++ b/src/components/diff-view.jsx
@@ -46,7 +46,7 @@ export default class DiffView extends React.Component {
   }
 
   render () {
-    const {a, b, diffType} = this.props;
+    const {diffType} = this.props;
     const {diff} = this.state;
 
     if (diffType && diffTypes[diffType].diffService === 'TODO') {

--- a/src/components/side-by-side-rendered-diff.jsx
+++ b/src/components/side-by-side-rendered-diff.jsx
@@ -20,21 +20,6 @@ export default class SideBySideRenderedDiff extends React.Component {
     this.frameB = null;
   }
 
-  // Simplistic rendering with remote content
-  // render () {
-  //     if (!this.props) {
-  //         return null;
-  //     }
-
-  //     return (
-  //         <div className="side-by-side-render">
-  //             <iframe src={this.props.a.uri} sandbox="allow-forms allow-scripts" />
-  //             <hr />
-  //             <iframe src={this.props.b.uri} sandbox="allow-forms allow-scripts" />
-  //         </div>
-  //     );
-  // }
-
   render () {
     if (!this.props) {
       return null;
@@ -54,7 +39,8 @@ export default class SideBySideRenderedDiff extends React.Component {
      * @returns {boolean}
      */
   shouldComponentUpdate (nextProps, nextState) {
-    return nextProps.a !== this.props.a || nextProps.b !== this.props.b;
+    return nextProps.diff.from_version_id !== this.props.diff.from_version_id
+      || nextProps.diff.to_version_id !== this.props.diff.to_version_id;
   }
 
   componentDidMount () {
@@ -66,18 +52,16 @@ export default class SideBySideRenderedDiff extends React.Component {
   }
 
   _updateContent () {
-    fetch(this.props.a.uri)
-      .then(response => response.text())
-      .then(rawSource => processSource(rawSource, this.props.page))
-      .then(source => {
-        this.frameA.setAttribute('srcdoc', source);
-      });
-    fetch(this.props.b.uri)
-      .then(response => response.text())
-      .then(rawSource => processSource(rawSource, this.props.page))
-      .then(source => {
-        this.frameB.setAttribute('srcdoc', source);
-      });
+    const raw_source = this.props.diff.content.diff;
+    const removals = raw_source.replace(/<ins[^>]*>[^]*?<\/ins>/ig, '');
+    const additions = raw_source.replace(/<del[^>]*>[^]*?<\/del>/ig, '');
+
+    this.frameA.setAttribute(
+      'srcdoc',
+      processSource(removals, this.props.page));
+    this.frameB.setAttribute(
+      'srcdoc',
+      processSource(additions, this.props.page));
   }
 }
 

--- a/src/components/side-by-side-rendered-diff.jsx
+++ b/src/components/side-by-side-rendered-diff.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 /**
  * @typedef {Object} SideBySideRenderedDiffProps
- * @property {Version} a The "from" version
- * @property {Version} b The "to" version
+ * @property {Diff} diff The diff to render
+ * @property {Page} page The page this diff pertains to
  */
 
 /**
@@ -65,7 +65,7 @@ export default class SideBySideRenderedDiff extends React.Component {
 
 /**
  * Create renderable HTML source code rendering either the added or removed
- * parts of the page from a an HTML diff representing the full change between
+ * parts of the page from an HTML diff representing the full change between
  * two versions.
  *
  * @param {string} source Full diff source code
@@ -140,16 +140,10 @@ function renderableDocument (sourceDocument, page) {
  * compensate for the fact that our diff is really a text diff that is
  * sensitive to the tree and not an actual tree diff.
  *
- * NOTE: this method is meant to be converted to source code and run *in the
- * context of the web page itself.*
- *
  * @param {string} type  Element type to remove, i.e. `ins` or `del`.
- * @param {HTMLDocument} [sourceDocument]  Document to remove elements from.
- *   If not sepecified, the current window's document will be used.
+ * @param {HTMLDocument} sourceDocument  Document to remove elements from.
  */
 function removeChangeElements (type, sourceDocument) {
-  sourceDocument = sourceDocument || window.document;
-
   function removeEmptyParents (elements) {
     if (elements.size === 0) return;
 

--- a/src/components/side-by-side-rendered-diff.jsx
+++ b/src/components/side-by-side-rendered-diff.jsx
@@ -116,6 +116,20 @@ function renderableDocument (sourceDocument, page) {
     sourceDocument.head.insertAdjacentElement('afterbegin', base);
   }
 
+  // The differ currently HTML-encodes the source code in these elements :\
+  // https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/94
+  sourceDocument.querySelectorAll('style, script').forEach(element => {
+    element.textContent = element.textContent
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#(x?)([0-9a-f]+);/ig, (text, hex, value) => {
+        const code = parseInt(value, hex ? 16 : 10);
+        return String.fromCharCode(code);
+      });
+  });
+
   return sourceDocument;
 }
 

--- a/src/constants/diff-types.js
+++ b/src/constants/diff-types.js
@@ -13,7 +13,7 @@ export const diffTypes = {
   },
   SIDE_BY_SIDE_RENDERED: {
     description: 'Side-by-Side Rendered',
-    diffService: 'html_source',  // HACK, real side-by-side doesn't exist yet
+    diffService: 'html_visual'
   },
   SIDE_BY_SIDE_TEXT: {
     description: 'Side-by-Side Text',


### PR DESCRIPTION
I think we can count this as fixes #83.

Replaces the raw side-by-side versions view with the highlighted one from edgi-govdata-archiving/web-monitoring-processing#78.

Note this depends on pending patches in 2 other repos:

- edgi-govdata-archiving/web-monitoring-processing#90
- edgi-govdata-archiving/web-monitoring-db#139

![screen shot 2017-09-15 at 5 27 53 pm](https://user-images.githubusercontent.com/74178/30507578-3f0c7332-9a3b-11e7-847a-0dc3bb370fe1.png)
