### PR TITLE
Hide annotation form for initial rollout until permissions are implemented

### DIFF
--- a/src/components/change-view.jsx
+++ b/src/components/change-view.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Link} from 'react-router-dom';
 import WebMonitoringDb from '../services/web-monitoring-db';
 import WebMonitoringApi from '../services/web-monitoring-api';
 import AnnotationForm from './annotation-form';
@@ -192,8 +191,6 @@ export default class ChangeView extends React.Component {
             <a className="lnk-action" href="#" onClick={this._toggleCollapsedView}>Toggle Signifiers</a>
             <i className="fa fa-pencil" aria-hidden="true" />
             <a className="lnk-action" href="#" onClick={this._annotateChange}>Update Record</a>
-            <i className="fa fa-list" aria-hidden="true" />
-            <Link to={`/${this.props.pageFilter}`} className="lnk-action">Back to list view</Link>
           </div>
           <div className="col-md-6 text-right">
             {markSignificant}

--- a/src/components/change-view.jsx
+++ b/src/components/change-view.jsx
@@ -95,7 +95,14 @@ export default class ChangeView extends React.Component {
 
   render () {
     const { page } = this.props;
-
+    /**
+     * TODO: Update `userCanAnnotate` to reflect real user permissions once implemented.
+     * `canAnnotate` doesn't exist yet, so always defaults to null.
+     * Effectively hiding the annotation for everyone until permissions are implemented.
+     * `canAnnotate` is arbitrary and DOES NOT reflect any intended permissions model or setup.
+     * https://github.com/edgi-govdata-archiving/web-monitoring-ui/issues/120
+     */
+    const userCanAnnotate = this.props.user.canAnnotate || null;
     if (!page || !page.versions) {
       // if haz no page, don't render
       return (<div></div>);
@@ -103,7 +110,7 @@ export default class ChangeView extends React.Component {
 
     return (
       <div className="change-view">
-        {this.renderSubmission()}
+        {userCanAnnotate ? this.renderSubmission() : null}
         {this.renderVersionSelector(page)}
         <DiffView page={page} diffType={this.state.diffType} a={this.props.from} b={this.props.to} />
       </div>

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -163,7 +163,6 @@ export default class PageDetails extends React.Component {
         annotateChange={this._annotateChange}
         user={this.props.user}
         onChangeSelectedVersions={this._navigateToChange}
-        pageFilter={this.props.pageFilter}
       />
     );
   }

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -85,16 +85,19 @@ export default class PageDetails extends React.Component {
       <div className="container-fluid container-page-view">
         <div className="row">
           <div className="col-md-9">
-            <h2 className="page-title">
+            <header>
+              <h2 className="page-title">
+                {this.state.page.title}
+              </h2>
               <a
                 className="diff_page_url"
                 href={this.state.page.url}
                 target="_blank"
                 rel="noopener"
               >
-                {this.state.page.title}
+                {this.state.page.url}
               </a>
-            </h2>
+            </header>
           </div>
           <div className="col-md-3">
             {this._renderPager()}


### PR DESCRIPTION
Fixes #130 

After conversation with @Mr0grog decided to go with a pseudo permissions route to hide the form rather than a config var. This lines up with our long term plans. I put in a phat comment to underscore that point. 

Also, made visible the url, which was requested off-hand during an analyst meeting. 