### PR TITLE
Show error messages when diffs fail to load

### DIFF
--- a/src/components/diff-view.jsx
+++ b/src/components/diff-view.jsx
@@ -50,11 +50,22 @@ export default class DiffView extends React.Component {
     const {diff} = this.state;
 
     if (diffType && diffTypes[diffType].diffService === 'TODO') {
-      return <div>No diff for '{diffTypes[diffType].description}' yet</div>;
+      return (
+        <p className="alert alert-warning" role="alert">
+          No diff for '{diffTypes[diffType].description}' yet
+        </p>
+      );
     }
 
     if (!diff) {
       return <Loading />;
+    }
+    else if (diff instanceof Error) {
+      return (
+        <p className="alert alert-danger" role="alert">
+          Error: {diff.message}
+        </p>
+      );
     }
 
     // TODO: if we have multiple ways to render content from a single service
@@ -119,6 +130,9 @@ export default class DiffView extends React.Component {
     // Promise.resolve(fromList || this.context.api.getDiff(pageId, aId, bId, changeDiffTypes[diffType]))
     this.setState({diff: null});
     this.context.api.getDiff(pageId, aId, bId, diffTypes[diffType].diffService)
+      .catch(error => {
+        return error;
+      })
       .then((diff) => {
         this.setState({
           diff: diff

--- a/src/services/web-monitoring-db.js
+++ b/src/services/web-monitoring-db.js
@@ -232,6 +232,7 @@ export default class WebMonitoringDb {
   getDiff (pageId, aId, bId, diffType) {
     return fetch(this._createUrl(`pages/${pageId}/changes/${aId}..${bId}/diff/${diffType}`, {format: 'json'}))
       .then(response => response.json())
+      .then(throwErrorResponse('Could not load diff'))
       .then(data => parseDiff(data.data));
   }
 
@@ -400,4 +401,29 @@ function parseDiff (data) {
     data.content = {diff: arrayFormat};
   }
   return data;
+}
+
+/**
+ * Create a function that will throw an error when given parsed response data
+ * that contains error information. Use this to reject the promise for an HTTP
+ * request.
+ *
+ * @param {string} summary If there are multiple errors or an error message
+ *   can not be found in the response, use this as the error message.
+ * @returns {Function}
+ */
+function throwErrorResponse (summary) {
+  return data => {
+    if (data.errors) {
+      const firstMessage = data.errors[0].title || data.errors[0].message;
+      const message = data.errors.length > 1 && summary || firstMessage;
+      const error = new Error(message);
+      error.details = data.errors;
+      throw error;
+    }
+    else if (data.error) {
+      throw new Error(data.error.title || data.error.message || summary);
+    }
+    return data;
+  };
 }


### PR DESCRIPTION
In `DiffView`, we now handle errors by making the `state.diff` the error instance. When rendering, we check whether the diff is an error object or normal data and render an error message if necessary.

This also changes the message for unimplemented diffs to display similarly, but with yellow "warning" colors.

Finally, this also adds a generic function to the WebMonitoringDb service for rejecting promises as error instances when they contain error data.

Fixes #112.

<img width="1005" alt="screen shot 2017-10-07 at 11 05 53 pm" src="https://user-images.githubusercontent.com/74178/31314376-1fcd17bc-abb4-11e7-9a1d-fa0b2bf5f909.png">
