### PR TITLE
Add better error handling for gulp watch task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+/* eslint no-console: "off" */
+
 const gulp = require('gulp');
 const babelify = require('babelify');
 const browserify = require('browserify');
@@ -9,20 +11,22 @@ const reportError = function (error) {
   notify({
     title: 'Task Failed [browserify]',
     message: 'See console.',
-    sound: 'Sosumi' // See: https://github.com/mikaelbr/node-notifier#all-notification-options-with-their-defaults
+    sound: 'Purr' // See: https://github.com/mikaelbr/node-notifier#all-notification-options-with-their-defaults
   }).write(error);
-
-  gutil.beep();
 
   // Pretty error reporting
   let report = '';
   const chalk = gutil.colors.white.bgRed;
-  const lineNumber = error.loc.line;
+
+  let message = error.stack;
+  if (error._babel && error instanceof SyntaxError) {
+    // Remove the Babel stack at the bottom of the formatted code.
+    message = error.stack.replace(/\n\s*at .*/g, '');
+  }
 
   report += chalk('TASK:') + ' browserify\n';
-  report += chalk('PROB:') + ` ${error.message}\n`;
-  report += chalk('LINE:') + ` ${lineNumber}\n`;
-  console.error(report); // eslint-disable-line
+  report += chalk('PROB:') + ` ${message}\n`;
+  console.error(report);
 
   // Prevent the 'watch' task from stopping
   this.emit('end');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,14 +2,37 @@ const gulp = require('gulp');
 const babelify = require('babelify');
 const browserify = require('browserify');
 const source = require('vinyl-source-stream');
+const gutil = require('gulp-util');
+const notify = require('gulp-notify');
 
-gulp.task('default', ['css', 'browserify']);
+const reportError = function (error) {
+  notify({
+    title: 'Task Failed [browserify]',
+    message: 'See console.',
+    sound: 'Sosumi' // See: https://github.com/mikaelbr/node-notifier#all-notification-options-with-their-defaults
+  }).write(error);
+
+  gutil.beep();
+
+  // Pretty error reporting
+  let report = '';
+  const chalk = gutil.colors.white.bgRed;
+  const lineNumber = error.loc.line;
+
+  report += chalk('TASK:') + ' browserify\n';
+  report += chalk('PROB:') + ` ${error.message}\n`;
+  report += chalk('LINE:') + ` ${lineNumber}\n`;
+  console.error(report); // eslint-disable-line
+
+  // Prevent the 'watch' task from stopping
+  this.emit('end');
+};
+
+gulp.task('default', ['css', 'img', 'browserify']);
 
 gulp.task('css', function () {
   return gulp.src('src/css/*').pipe(gulp.dest('dist/css'));
 });
-
-gulp.task('default', ['css', 'img', 'browserify']);
 
 gulp.task('img', function () {
   return gulp.src('src/img/*').pipe(gulp.dest('dist/img'));
@@ -26,6 +49,7 @@ gulp.task('browserify', function () {
   })
     .transform(babelify)
     .bundle()
+    .on('error', reportError)
     .pipe(source('bundle.js'))
     .pipe(gulp.dest('dist'));
 });
@@ -35,3 +59,4 @@ gulp.task('watch', function() {
   gulp.watch('src/**/*.css', ['css']);
   gulp.watch('src/img/*', ['img']);
 });
+

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "ejs": "^2.5.5",
     "express": "^4.14.1",
     "googleapis": "^19.0.0",
+    "gulp-notify": "^3.0.0",
     "request": "^2.81.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2406,6 +2406,16 @@ gtoken@^1.2.1:
     mime "^1.2.11"
     request "^2.72.0"
 
+gulp-notify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-notify/-/gulp-notify-3.0.0.tgz#a04b8af9acdbe4e63c845678ce0c3d30694c59a3"
+  dependencies:
+    gulp-util "^3.0.8"
+    lodash.template "^4.4.0"
+    node-notifier "^5.0.1"
+    node.extend "^1.1.6"
+    through2 "^2.0.3"
+
 gulp-util@^3.0.0, gulp-util@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
@@ -2879,6 +2889,10 @@ is-utf8@^0.2.0:
 is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
+
+is@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/is/-/is-3.2.1.tgz#d0ac2ad55eb7b0bec926a5266f6c662aaa83dca5"
 
 isarray@0.0.1, isarray@~0.0.1:
   version "0.0.1"
@@ -3413,7 +3427,7 @@ lodash._reevaluate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz#58bc74c40664953ae0b124d806996daca431e2ed"
 
-lodash._reinterpolate@^3.0.0:
+lodash._reinterpolate@^3.0.0, lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
 
@@ -3537,12 +3551,25 @@ lodash.template@^3.0.0:
     lodash.restparam "^3.0.0"
     lodash.templatesettings "^3.0.0"
 
+lodash.template@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
+  dependencies:
+    lodash._reinterpolate "~3.0.0"
+    lodash.templatesettings "^4.0.0"
+
 lodash.templatesettings@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz#fb307844753b66b9f1afa54e262c745307dba8e5"
   dependencies:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
+
+lodash.templatesettings@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz#2b4d4e95ba440d915ff08bc899e4553666713316"
+  dependencies:
+    lodash._reinterpolate "~3.0.0"
 
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
@@ -3759,7 +3786,7 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
-node-notifier@^5.0.2:
+node-notifier@^5.0.1, node-notifier@^5.0.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.1.2.tgz#2fa9e12605fa10009d44549d6fcd8a63dde0e4ff"
   dependencies:
@@ -3781,6 +3808,12 @@ node-pre-gyp@^0.6.29:
     semver "^5.3.0"
     tar "^2.2.1"
     tar-pack "^3.4.0"
+
+node.extend@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/node.extend/-/node.extend-1.1.6.tgz#a7b882c82d6c93a4863a5504bd5de8ec86258b96"
+  dependencies:
+    is "^3.1.0"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -4983,7 +5016,7 @@ through2@^0.6.1:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
-through2@^2.0.0:
+through2@^2.0.0, through2@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:


### PR DESCRIPTION
Should've done this ages ago, but finally got around to handling errors during build so that we don't break the watch task. After assigning issues to milestones and realizing how much still needed to be done, thought I should get this done to make development easier.

Fixes #71 

I decided to not go the `watchify` + `errorify` route because `errorify` hasn't been updated in 2 years and has a critical issue where it is [breaking with the newest version of watchify](https://github.com/zertosh/errorify/issues/7) and it doesn't look like the maintainer is going to address that. I couldn't find a good solution to notify in the browser. I tried using `browser-sync` but I couldn't figure out how proxying worked with it and it seemed like it would just be more confusing for other contributors (and myself!)

Went with a simple notification and console message. Didn't want to do anything too involved because [webpack is on the horizon](https://github.com/edgi-govdata-archiving/web-monitoring-ui/issues/88), but this seemed useful now.