### PR TITLE
HOTFIX: stop using the old differ for source

### DIFF
--- a/src/constants/diff-types.js
+++ b/src/constants/diff-types.js
@@ -5,7 +5,7 @@ export const diffTypes = {
   },
   HIGHLIGHTED_SOURCE: {
     description: 'Highlighted Source',
-    diffService: 'source',
+    diffService: 'html_source',
   },
   HIGHLIGHTED_RENDERED: {
     description: 'Highlighted Rendered',
@@ -21,7 +21,7 @@ export const diffTypes = {
   },
   CHANGES_ONLY_SOURCE: {
     description: 'Changes Only Source',
-    diffService: 'source',
+    diffService: 'html_source',
   }
 };
 


### PR DESCRIPTION
We were supposed to have turned this off months ago now. It got overlooked.