### PR TITLE
Upgrade to Circle Ci 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:6.11.1
+    steps:
+      - checkout
+dependencies:
+  override:
+    - yarn
+test:
+  override:
+    - yarn test
+steps:
+  - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,15 @@ jobs:
       - image: circleci/node:6.11.1
     steps:
       - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
       - run:
-          name: dependancies
+          name: Dependencies
           command: yarn
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./yarn-installations
       - run:
-          name: test
+          name: Test
           command: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
-            - ./yarn-installations
+            - ./node_modules
       - run:
           name: Test
           command: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,9 @@ jobs:
       - image: circleci/node:6.11.1
     steps:
       - checkout
-dependencies:
-  override:
-    - yarn
-test:
-  override:
-    - yarn test
-steps:
-  - checkout
+      - run:
+          name: dependancies
+          command: yarn
+      - run:
+          name: test
+          command: yarn test

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,0 @@
-machine:
-  node:
-    version: 6.11.1
-dependencies:
-  override:
-    - yarn
-test:
-  override:
-    - yarn test

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "jest": {},
   "author": "",
-  "license": "MIT",
+  "license": "GPL-3.0",
   "engines": {
     "node": "8.2.1"
   }


### PR DESCRIPTION
Closes https://github.com/edgi-govdata-archiving/web-monitoring-ui/issues/91, this PR is to upgrade Circle CI to 2.0 for this project by applying the steps outlined in [the circle ci documentation](https://circleci.com/docs/2.0/migrating-from-1-2/) to the existing `circle.yml` file.