### PR TITLE
Refactor versionista info

### DIFF
--- a/src/components/__tests__/versionista-info.test.jsx
+++ b/src/components/__tests__/versionista-info.test.jsx
@@ -57,7 +57,7 @@ describe('Versionista-Info', () => {
 
   it('Prints a message if only one version is specified', () => {
     const vInfo = render(<VersionistaInfo from={from} to={from} />);
-    expect(vInfo.text()).toBe('There is only one version. No diff to display.');
+    expect(vInfo.text()).toBe('No link to display because the selected versions are the same.');
   });
 
   describe('Link tests', () => {

--- a/src/components/__tests__/versionista-info.test.jsx
+++ b/src/components/__tests__/versionista-info.test.jsx
@@ -55,16 +55,16 @@ describe('Versionista-Info', () => {
     expect(vInfo.text()).toBe('');
   });
 
-  it('Prints a message if only one version is specified', () => {
+  it('Outputs link to page view if both versions are the same.', () => {
     const vInfo = render(<VersionistaInfo from={from} to={from} />);
-    expect(vInfo.text()).toBe('No link to display because the selected versions are the same.');
+    const { attribs: { href } } = vInfo.find('a')[0];
+    expect(href).toBe('https://versionista.com/74273/6210778');
   });
 
   describe('Link tests', () => {
     it('Gives us a link', () => {
       const versions = [];
-      versions.push(to);
-      versions.push(from);
+      versions.push(to, from);
 
       const vInfo = render(<VersionistaInfo to={to} from={from} versions={versions} />);
       const { attribs: { href } } = vInfo.find('a')[0];
@@ -86,8 +86,7 @@ describe('Versionista-Info', () => {
 
     it('Switches `to` and `from` to give us correct Versionista link', () => {
       const versions = [];
-      versions.push(to);
-      versions.push(from);
+      versions.push(to, from);
 
       const vInfo = render(<VersionistaInfo to={from} from={to} versions={versions} />);
       const { attribs: { href } } = vInfo.find('a')[0];
@@ -115,8 +114,7 @@ describe('Versionista-Info', () => {
       for (let i = 0; i < 50; i++) {
         versions.push(filler);
       }
-      versions.push(to);
-      versions.push(from);
+      versions.push(to, from);
 
       const vInfo = render(<VersionistaInfo to={to} from={from} versions={versions} />);
 
@@ -137,19 +135,10 @@ describe('Versionista-Info', () => {
       expect(vInfo.text()).toMatch(format);
       const matches = vInfo.text().match(format);
 
-      // var matches, output = [];
-      // while (matches = regex.exec(vInfo.text())) {
-      //     output.push(matches[1]);
-      // }
-
-      // const fromUTC = 'January 18, 2017, 3:17:31 AM';
       const fromDate = new Date(matches[1]);
-      // const fromLocalized = dateFormatter.format(new Date(fromDate));
       expect(fromDate).toEqual(from.capture_time);
 
-      // const toUTC = 'October 8, 2017, 5:58:12 AM';
       const toDate = new Date(matches[2]);
-      // const toLocalized = dateFormatter.format(new Date(toDate));
       expect(toDate).toEqual(to.capture_time);
     });
   });

--- a/src/components/__tests__/versionista-info.test.jsx
+++ b/src/components/__tests__/versionista-info.test.jsx
@@ -43,26 +43,26 @@ describe('Versionista-Info', () => {
     }
   };
 
-  it('Outputs nothing if no versions are specified', () => {
+  it('outputs nothing if no versions are specified', () => {
     const vInfo = render(<VersionistaInfo />);
     expect(vInfo.text()).toBe('');
   });
 
-  it('Outputs nothing if either version is not from versionista', () => {
+  it('outputs nothing if either version is not from versionista', () => {
     const otherFrom = Object.assign({}, from, {source_type: 'elsewhere'});
     const otherTo = Object.assign({}, to, {source_type: 'elsewhere'});
     const vInfo = render(<VersionistaInfo from={otherFrom} to={otherTo} />);
     expect(vInfo.text()).toBe('');
   });
 
-  it('Outputs link to page view if both versions are the same.', () => {
+  it('outputs link to page view if both versions are the same', () => {
     const vInfo = render(<VersionistaInfo from={from} to={from} />);
     const { attribs: { href } } = vInfo.find('a')[0];
     expect(href).toBe('https://versionista.com/74273/6210778');
   });
 
   describe('Link tests', () => {
-    it('Gives us a link', () => {
+    it('outputs correct link in normal situation', () => {
       const versions = [];
       versions.push(to, from);
 
@@ -71,7 +71,7 @@ describe('Versionista-Info', () => {
       expect(href).toBe('https://versionista.com/74273/6210778/13117888:9452489');
     });
 
-    it('Gives us a link if `from` is first version', () => {
+    it('outputs link if `from` is first version of set of >50 versions', () => {
       const versions = [];
       versions.push(to);
       for (let i = 0; i < 50; i++) {
@@ -84,7 +84,7 @@ describe('Versionista-Info', () => {
       expect(href).toBe('https://versionista.com/74273/6210778/13117888:9452489');
     });
 
-    it('Switches `to` and `from` to give us correct Versionista link', () => {
+    it('switches `to` and `from` to give us correct Versionista link', () => {
       const versions = [];
       versions.push(to, from);
 
@@ -95,7 +95,7 @@ describe('Versionista-Info', () => {
   });
 
   describe('Message tests', () => {
-    it('Tells us `from` is too old', () => {
+    it('outputs `from` is too old', () => {
       const versions = [];
       versions.push(to);
       for (let i = 0; i < 50; i++) {
@@ -104,12 +104,11 @@ describe('Versionista-Info', () => {
       versions.push(from, filler);
 
       const vInfo = render(<VersionistaInfo to={to} from={from} versions={versions} />);
-
       const fromDate = new Date(vInfo.text().match(/from (.*) is/)[1]);
       expect(fromDate).toEqual(from.capture_time);
     });
 
-    it('Tells us `to` is too old', () => {
+    it('outputs `to` is too old', () => {
       const versions = [];
       for (let i = 0; i < 50; i++) {
         versions.push(filler);
@@ -117,12 +116,11 @@ describe('Versionista-Info', () => {
       versions.push(to, from);
 
       const vInfo = render(<VersionistaInfo to={to} from={from} versions={versions} />);
-
       const toDate = new Date(vInfo.text().match(/from (.*) is/)[1]);
       expect(toDate).toEqual(to.capture_time);
     });
 
-    it('Tells us both are too old', () => {
+    it('outputs both are too old', () => {
       const versions = [];
       for (let i = 0; i < 50; i++) {
         versions.push(filler);
@@ -130,16 +128,7 @@ describe('Versionista-Info', () => {
       versions.push(to, from, filler);
 
       const vInfo = render(<VersionistaInfo to={to} from={from} versions={versions} />);
-
-      const format = /from ([^.]+?) and ([^.]+?) are/;
-      expect(vInfo.text()).toMatch(format);
-      const matches = vInfo.text().match(format);
-
-      const fromDate = new Date(matches[1]);
-      expect(fromDate).toEqual(from.capture_time);
-
-      const toDate = new Date(matches[2]);
-      expect(toDate).toEqual(to.capture_time);
+      expect(vInfo.text()).toBe('Both versions are no longer in Versionista. ');
     });
   });
 });

--- a/src/components/versionista-info.jsx
+++ b/src/components/versionista-info.jsx
@@ -10,7 +10,7 @@ import {dateFormatter} from '../scripts/formatters';
  */
 
 /**
- * This component either creates a link that points to the corresponding Versionista diff
+ * Creates a link that points to the corresponding Versionista diff
  * or provides info if a diff is no longer in Versionista.
  *
  * @class VersionistaInfo
@@ -27,7 +27,7 @@ export default class VersionistaInfo extends React.Component {
       return null;
     }
     else if (this.props.from === this.props.to) {
-      message = <span>There is only one version. No diff to display.</span>;
+      message = <span>No link to display because the selected versions are the same.</span>;
     }
     else {
       message = this.renderMissingVersionsMessage();
@@ -35,7 +35,7 @@ export default class VersionistaInfo extends React.Component {
 
     return (
       <div className="versionista-info">
-        {(message) ? message : this.renderLink()}
+        {(message) ? message : this.renderDiffLink()}
       </div>
     );
   }
@@ -64,10 +64,12 @@ export default class VersionistaInfo extends React.Component {
     );
   }
 
-  renderLink () {
-    const account = this.props.from.source_metadata.account;
-    const siteId = this.props.from.source_metadata.site_id;
-    const pageId = this.props.from.source_metadata.page_id;
+  renderDiffLink () {
+    const {
+      account,
+      site_id,
+      page_id
+    } = this.props.from.source_metadata;
 
     // Ensure IDs are in order -- Versionista doesn't handle this like we do.
     let fromVersionId = +this.props.from.source_metadata.version_id;
@@ -79,8 +81,8 @@ export default class VersionistaInfo extends React.Component {
     return (
       <span>
         <a
-          target='_blank'
-          href={`https://versionista.com/${siteId}/${pageId}/${toVersionId}:${fromVersionId}`}
+          target="_blank"
+          href={`https://versionista.com/${site_id}/${page_id}/${toVersionId}:${fromVersionId}`}
         >
           View this diff in Versionista (account: {account})
         </a>

--- a/src/components/versionista-info.jsx
+++ b/src/components/versionista-info.jsx
@@ -28,7 +28,7 @@ export default class VersionistaInfo extends React.Component {
     }
     else if (this.props.from === this.props.to
       || this.props.to.uuid === this.props.from.uuid) {
-        message = this.renderPageLink();
+      message = this.renderPageLink();
     }
     else {
       message = this.renderMissingVersionsMessage();
@@ -47,27 +47,24 @@ export default class VersionistaInfo extends React.Component {
     const tooltip = (
       <span>
         <i
-            className="fa fa-info-circle"
-            data-for="message-tooltip"
-            data-tip="Versionista stores only 50 versions: The latest 49 and the first captured version."
-            aria-hidden="true"
-          />
+          className="fa fa-info-circle"
+          data-for="message-tooltip"
+          data-tip="Versionista stores only 50 versions: The latest 49 and the first captured version."
+          aria-hidden="true"
+        />
         <StandardTooltip id="message-tooltip" />
       </span>
     );
 
     switch (datesWithoutDiff.length) {
-      case 0:
-        return null;
-        break;
-      case 1:
-        return <span>Version from <strong>{datesWithoutDiff[0]}</strong> is no longer in Versionista. {tooltip}</span>
-        break;
-      case 2:
-        return <span>Both versions are no longer in Versionista. {tooltip}</span>;
-        break;
-      default:
-        return null;
+    case 0:
+      return null;
+    case 1:
+      return <span>Version from <strong>{datesWithoutDiff[0]}</strong> is no longer in Versionista. {tooltip}</span>;
+    case 2:
+      return <span>Both versions are no longer in Versionista. {tooltip}</span>;
+    default:
+      return null;
     }
   }
 

--- a/src/components/versionista-info.jsx
+++ b/src/components/versionista-info.jsx
@@ -34,15 +34,12 @@ export default class VersionistaInfo extends React.Component {
   }
 
   getMessage () {
-    let message = null;
-    if (this.props.from === this.props.to
-      || this.props.to.uuid === this.props.from.uuid) {
-      message = this.renderPageLink();
+    if (this.props.to.uuid === this.props.from.uuid) {
+      return this.renderPageLink();
     }
     else {
-      message = this.renderMissingVersionsMessage();
+      return this.renderMissingVersionsMessage();
     }
-    return message;
   }
 
   renderPageLink () {

--- a/src/components/versionista-info.jsx
+++ b/src/components/versionista-info.jsx
@@ -19,42 +19,51 @@ import {dateFormatter} from '../scripts/formatters';
  */
 export default class VersionistaInfo extends React.Component {
   render () {
-    let message;
     if (!this.props.from
      || !this.props.to
      || this.props.from.source_type !== 'versionista'
      || this.props.to.source_type !== 'versionista') {
       return null;
     }
-    else if (this.props.from === this.props.to
+
+    return (
+      <div className="versionista-info">
+        {this.getMessage() || this.renderDiffLink()}
+      </div>
+    );
+  }
+
+  getMessage () {
+    let message = null;
+    if (this.props.from === this.props.to
       || this.props.to.uuid === this.props.from.uuid) {
       message = this.renderPageLink();
     }
     else {
       message = this.renderMissingVersionsMessage();
     }
+    return message;
+  }
+
+  renderPageLink () {
+    const {
+      account,
+      site_id,
+      page_id
+    } = this.props.from.source_metadata;
 
     return (
-      <div className="versionista-info">
-        {(message) ? message : this.renderDiffLink()}
-      </div>
+      <a target="_blank" href={`https://versionista.com/${site_id}/${page_id}`}>
+        The selected versions are the same. View the page in Versionista. (account: {account})
+      </a>
     );
   }
 
   renderMissingVersionsMessage () {
     let datesWithoutDiff = this.getDatesWithoutDiff();
 
-    const tooltip = (
-      <span>
-        <i
-          className="fa fa-info-circle"
-          data-for="message-tooltip"
-          data-tip="Versionista stores only 50 versions: The latest 49 and the first captured version."
-          aria-hidden="true"
-        />
-        <StandardTooltip id="message-tooltip" />
-      </span>
-    );
+    const tooltip = this.renderTooltip(
+      'Versionista stores only 50 versions: The latest 49 and the first captured version.');
 
     switch (datesWithoutDiff.length) {
     case 0:
@@ -64,7 +73,7 @@ export default class VersionistaInfo extends React.Component {
     case 2:
       return <span>Both versions are no longer in Versionista. {tooltip}</span>;
     default:
-      return null;
+      return <span>Something unexpected happened. Please inform developers with link to this page.</span>;
     }
   }
 
@@ -90,29 +99,23 @@ export default class VersionistaInfo extends React.Component {
         >
           View this diff in Versionista (account: {account})
         </a>
-        <i
-          className="fa fa-info-circle"
-          data-for="versionista-tooltip"
-          data-tip="This link to Versionista is temporary and for debugging the transition to the app."
-          aria-hidden="true"
-        />
-        <StandardTooltip id="versionista-tooltip" />
+        {this.renderTooltip(
+          'This link to Versionista is temporary and for debugging the transition to the app.')}
       </span>
     );
   }
 
-  renderPageLink () {
-    const {
-      account,
-      site_id,
-      page_id
-    } = this.props.from.source_metadata;
-
-    return (
-      <a target="_blank" href={`https://versionista.com/${site_id}/${page_id}`}>
-        The selected versions are the same. View the page in Versionista. (account: {account})
-      </a>
-    );
+  renderTooltip (tip) {
+    return [
+      <i
+        className="fa fa-info-circle"
+        data-for="versionista-tooltip"
+        data-tip={tip}
+        aria-hidden="true"
+        key="icon"
+      />,
+      <StandardTooltip id="versionista-tooltip" key="versionistaTooltip" />
+    ];
   }
 
   /**

--- a/src/components/versionista-info.jsx
+++ b/src/components/versionista-info.jsx
@@ -27,7 +27,7 @@ export default class VersionistaInfo extends React.Component {
       return null;
     }
     else if (this.props.from === this.props.to) {
-      message = <span>No link to display because the selected versions are the same.</span>;
+      message = this.renderPageLink();
     }
     else {
       message = this.renderMissingVersionsMessage();
@@ -94,6 +94,19 @@ export default class VersionistaInfo extends React.Component {
         />
         <StandardTooltip id="versionista-tooltip" />
       </span>
+    );
+  }
+
+  renderPageLink () {
+    const {
+      account,
+      site_id,
+      page_id
+    } = this.props.from.source_metadata;
+    return (
+      <a target="_blank" href={`https://versionista.com/${site_id}/${page_id}`}>
+        The selected versions are the same. View the page in Versionista. (account: {account})
+      </a>
     );
   }
 

--- a/src/components/versionista-info.jsx
+++ b/src/components/versionista-info.jsx
@@ -26,8 +26,9 @@ export default class VersionistaInfo extends React.Component {
      || this.props.to.source_type !== 'versionista') {
       return null;
     }
-    else if (this.props.from === this.props.to) {
-      message = this.renderPageLink();
+    else if (this.props.from === this.props.to
+      || this.props.to.uuid === this.props.from.uuid) {
+        message = this.renderPageLink();
     }
     else {
       message = this.renderMissingVersionsMessage();
@@ -42,26 +43,32 @@ export default class VersionistaInfo extends React.Component {
 
   renderMissingVersionsMessage () {
     let datesWithoutDiff = this.getDatesWithoutDiff();
-    if (datesWithoutDiff.length === 0) {
-      return null;
-    }
 
-    const missingDates = datesWithoutDiff.join(' and ');
-    const plural = datesWithoutDiff.length > 1;
-
-    return (
+    const tooltip = (
       <span>
-        Version{plural ? 's' : ''} from <strong>{missingDates}</strong>
-        {plural ? ' are' : ' is'} no longer in Versionista.
         <i
-          className="fa fa-info-circle"
-          data-for="message-tooltip"
-          data-tip="Versionista stores only 50 versions: The latest 49 and the first captured version."
-          aria-hidden="true"
-        />
+            className="fa fa-info-circle"
+            data-for="message-tooltip"
+            data-tip="Versionista stores only 50 versions: The latest 49 and the first captured version."
+            aria-hidden="true"
+          />
         <StandardTooltip id="message-tooltip" />
       </span>
     );
+
+    switch (datesWithoutDiff.length) {
+      case 0:
+        return null;
+        break;
+      case 1:
+        return <span>Version from <strong>{datesWithoutDiff[0]}</strong> is no longer in Versionista. {tooltip}</span>
+        break;
+      case 2:
+        return <span>Both versions are no longer in Versionista. {tooltip}</span>;
+        break;
+      default:
+        return null;
+    }
   }
 
   renderDiffLink () {
@@ -103,6 +110,7 @@ export default class VersionistaInfo extends React.Component {
       site_id,
       page_id
     } = this.props.from.source_metadata;
+
     return (
       <a target="_blank" href={`https://versionista.com/${site_id}/${page_id}`}>
         The selected versions are the same. View the page in Versionista. (account: {account})


### PR DESCRIPTION
Additional cleanup to the versionista-info component. Decided to go with Mr0grog's suggestion to link to the page in Versionista if both versions are the same. Also cleaned up some text for the user and tests.