### PR TITLE
Create route for single version

### DIFF
--- a/src/components/loading.jsx
+++ b/src/components/loading.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
 
 export default class Loading extends React.Component {
-
-  constructor () {
-    super();
-  }
-
   render () {
-    return (<object type="image/svg+xml" data="/img/infinity-loader.svg" className="loading" />);
+    return (
+      <div className="loading">
+        <object type="image/svg+xml" data="/img/infinity-loader.svg" />
+      </div>
+    );
   }
 }

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -149,9 +149,9 @@ export default class PageDetails extends React.Component {
     // TODO: should we show 404 for bad versions? (null vs. undefined here)
     const versionData = this._versionsToRender();
     if (!versionData) {
-      let [to, from] = this.state.page.versions;
-      from = from || to;
+      let [to, from] = this._parseVersions() || this.state.page.versions;
 
+      from = from || to;
       if (from && to) {
         return <Redirect to={this._getChangeUrl(from, to)} />;
       }
@@ -177,7 +177,26 @@ export default class PageDetails extends React.Component {
       const [fromId, toId] = this.props.match.params.change.split('..');
       const from = this.state.page.versions.find(v => v.uuid === fromId);
       const to = this.state.page.versions.find(v => v.uuid === toId);
+
       return (from && to) ? {from, to} : null;
+    }
+  }
+
+  // Handles '..toId' case, setting `from` to the previous version relative to the provided one
+  _parsedVersionsToRender () {
+    if (this.props.match.params.change) {
+      let fromIndex, toIndex, from, to;
+      const [fromId, toId] = this.props.match.params.change.split('..');
+
+      if (!fromId && toId) {
+        toIndex = this.state.page.versions.findIndex(v => v.uuid === toId);
+        fromIndex = toIndex + 1;
+        from = this.state.page.versions[fromIndex];
+        to = this.state.page.versions[toIndex];
+        from = from || to;
+      }
+
+      return (from && to) ? [to, from] : null;
     }
   }
 

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -179,7 +179,7 @@ export default class PageDetails extends React.Component {
     let from = this.state.page.versions.find(v => v.uuid === fromId);
     let to = this.state.page.versions.find(v => v.uuid === toId);
 
-    // Changes w/ no `to` are invalid, but those where `from` was never
+    // Changes with no `to` are invalid, but those where `from` was never
     // specified are OK (it’ll be considered relative to `to`)
     if (!to || fromId && !from) {
       to = from = null;

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -149,7 +149,7 @@ export default class PageDetails extends React.Component {
     // TODO: should we show 404 for bad versions? (null vs. undefined here)
     const versionData = this._versionsToRender();
     if (!versionData) {
-      let [to, from] = this._parseVersions() || this.state.page.versions;
+      let [to, from] = this._parsedVersionsToRender() || this.state.page.versions;
 
       from = from || to;
       if (from && to) {

--- a/src/components/version-redirect.jsx
+++ b/src/components/version-redirect.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {Redirect} from 'react-router-dom';
+
+export default class VersionRedirect extends React.Component {
+  constructor (props) {
+    super (props);
+    this.state = {
+      pageId: null
+    };
+  }
+
+  componentDidMount () {
+    const versionId = this.props.match.params.versionId;
+    this.props.api.getVersionById(versionId).then(data => {
+      this.setState({pageId: data.page_uuid});
+    });
+  }
+
+  render () {
+    if (!this.state.pageId) {
+      return null;
+    }
+    return <Redirect to={`/page/${this.state.pageId}/..${this.props.match.params.versionId}`} />;
+  }
+}

--- a/src/components/version-redirect.jsx
+++ b/src/components/version-redirect.jsx
@@ -16,7 +16,11 @@ export default class VersionRedirect extends React.Component {
   componentDidMount () {
     const versionId = this.props.match.params.versionId;
     this.context.api.getVersion(versionId)
-      .then(data => this.setState({pageId: data.page_uuid}))
+      .then(data => {
+        if (this.props.match.params.versionId === versionId) {
+          this.setState({pageId: data.page_uuid});
+        }
+      })
       .catch(error => this.setState({error: error}));
   }
 
@@ -33,10 +37,11 @@ export default class VersionRedirect extends React.Component {
     if (!this.state.pageId) {
       return <Loading />;
     }
+
     return <Redirect to={`/page/${this.state.pageId}/..${this.props.match.params.versionId}`} />;
   }
 }
 
 VersionRedirect.contextTypes = {
   api: PropTypes.instanceOf(WebMonitoringDb)
-}
+};

--- a/src/components/version-redirect.jsx
+++ b/src/components/version-redirect.jsx
@@ -1,6 +1,8 @@
+import Loading from './loading';
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Redirect} from 'react-router-dom';
-import Loading from './loading';
+import WebMonitoringDb from '../services/web-monitoring-db';
 
 export default class VersionRedirect extends React.Component {
   constructor (props) {
@@ -13,7 +15,7 @@ export default class VersionRedirect extends React.Component {
 
   componentDidMount () {
     const versionId = this.props.match.params.versionId;
-    this.props.api.getVersionById(versionId)
+    this.context.api.getVersion(versionId)
       .then(data => this.setState({pageId: data.page_uuid}))
       .catch(error => this.setState({error: error}));
   }
@@ -23,7 +25,7 @@ export default class VersionRedirect extends React.Component {
       return (
         <p className="alert alert-danger" role="alert">
           Error: We couldn't find the version you're looking for.
-          Please check you provided the correct versionID or alert the dev team.
+          Please check you provided the correct versionID.
         </p>
       );
     }
@@ -33,4 +35,8 @@ export default class VersionRedirect extends React.Component {
     }
     return <Redirect to={`/page/${this.state.pageId}/..${this.props.match.params.versionId}`} />;
   }
+}
+
+VersionRedirect.contextTypes = {
+  api: PropTypes.instanceOf(WebMonitoringDb)
 }

--- a/src/components/version-redirect.jsx
+++ b/src/components/version-redirect.jsx
@@ -1,24 +1,35 @@
 import React from 'react';
 import {Redirect} from 'react-router-dom';
+import Loading from './loading';
 
 export default class VersionRedirect extends React.Component {
   constructor (props) {
     super (props);
     this.state = {
-      pageId: null
+      pageId: null,
+      error: null
     };
   }
 
   componentDidMount () {
     const versionId = this.props.match.params.versionId;
-    this.props.api.getVersionById(versionId).then(data => {
-      this.setState({pageId: data.page_uuid});
-    });
+    this.props.api.getVersionById(versionId)
+      .then(data => this.setState({pageId: data.page_uuid}))
+      .catch(error => this.setState({error: error}));
   }
 
   render () {
+    if (this.state.error) {
+      return (
+        <p className="alert alert-danger" role="alert">
+          Error: We couldn't find the version you're looking for.
+          Please check you provided the correct version ID or alert the dev team.
+        </p>
+      );
+    }
+
     if (!this.state.pageId) {
-      return null;
+      return <Loading />;
     }
     return <Redirect to={`/page/${this.state.pageId}/..${this.props.match.params.versionId}`} />;
   }

--- a/src/components/version-redirect.jsx
+++ b/src/components/version-redirect.jsx
@@ -23,7 +23,7 @@ export default class VersionRedirect extends React.Component {
       return (
         <p className="alert alert-danger" role="alert">
           Error: We couldn't find the version you're looking for.
-          Please check you provided the correct version ID or alert the dev team.
+          Please check you provided the correct versionID or alert the dev team.
         </p>
       );
     }

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -9,6 +9,7 @@ import LoginForm from './login-form';
 import NavBar from './nav-bar';
 import PageDetails from './page-details';
 import PageList from './page-list';
+import VersionRedirect from './version-redirect';
 
 const configuration = window.webMonitoringConfig;
 
@@ -166,6 +167,7 @@ export default class WebMonitoringUi extends React.Component {
                 pages={this.state[this.state.pageFilter]}
               />
             }/>
+            <Route path="/version/:versionId" render={(routeProps) => <VersionRedirect api={api} {...routeProps} />} />
           </div>
         </Router>
         {modal}

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -167,7 +167,7 @@ export default class WebMonitoringUi extends React.Component {
                 pages={this.state[this.state.pageFilter]}
               />
             }/>
-            <Route path="/version/:versionId" render={(routeProps) => <VersionRedirect api={api} {...routeProps} />} />
+            <Route path="/version/:versionId" component={VersionRedirect} />
           </div>
         </Router>
         {modal}

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -361,10 +361,9 @@ iframe {
 }
 
 .loading {
-  position: absolute;
-  left: 50%;
-  margin-left: -37px;
-  height: 70px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .versionista-info {

--- a/src/services/web-monitoring-db.js
+++ b/src/services/web-monitoring-db.js
@@ -195,23 +195,11 @@ export default class WebMonitoringDb {
   }
 
   /**
-     * Get a single version of a page.
-     * @param {string} pageId
-     * @param {string} versionId
-     * @returns {Promise<Version>}
-     */
-  getVersion (pageId, versionId) {
-    return this._request(this._createUrl(`pages/${pageId}/versions/${versionId}`))
-      .then(response => response.json())
-      .then(data => parseVersion(data.data));
-  }
-
-  /**
-   * Get a single version
+   * Get a single version of a page
    * @param {string} versionId
    * @returns {Promise<Version>}
    */
-  getVersionById (versionId) {
+  getVersion (versionId) {
     return this._request(this._createUrl(`versions/${versionId}`))
       .then(response => response.json())
       .then(data => parseVersion(data.data));

--- a/src/services/web-monitoring-db.js
+++ b/src/services/web-monitoring-db.js
@@ -207,6 +207,17 @@ export default class WebMonitoringDb {
   }
 
   /**
+   * Get a single version
+   * @param {string} versionId
+   * @returns {Promise<Version>}
+   */
+  getVersionById (versionId) {
+    return this._request(this._createUrl(`versions/${versionId}`))
+      .then(response => response.json())
+      .then(data => parseVersion(data.data));
+  }
+
+  /**
      * Get details on a change between two versions
      * @param {string} pageId
      * @param {string} fromVersion


### PR DESCRIPTION
Fixes #145 

Added logic to handle `/page/page_uuid/..versionId` so that it will show the change between the provided version and the one previous to it.
Added the new route, which is a component that builds a redirect to that path.
Also had to add a function to the db api to look up a version by `versionId` so that I could get the `page_uuid` to build the route.