### PR TITLE
Add css to make change-view full height of page

### DIFF
--- a/src/css/diff.css
+++ b/src/css/diff.css
@@ -7,12 +7,12 @@ ins {
 
 .side-by-side-render {
     display: flex;
+    flex: 1 0 auto;
 }
 
 .side-by-side-render > iframe {
     border: 1px solid #ccc;
     border-radius: 2px;
-    min-height: 40em;
     width: 100%;
 }
 

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -11,17 +11,6 @@ html, #web-monitoring-ui-root, #web-monitoring-ui-root > div {
   flex-direction: column;
 }
 
-.navbar {
-  flex: 0 0 auto;
-}
-
-.container-page-view {
-  display: flex;
-  flex: 1 0 auto;
-  flex-direction: column;
-  padding: 15px;
-}
-
 .container-page-view > .row, .versionista-info, .version-selector {
   flex: 0 0 auto;
 }
@@ -46,7 +35,14 @@ body {
 .container-list-view, .container-page-view {
     background: white;
     color: #444;
-    margin: 5px 0 ;
+    margin: 55px 0 5px;
+}
+
+.container-page-view {
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: column;
+  padding: 15px;
 }
 
 /* ===== Nav Bar ===== */
@@ -91,7 +87,13 @@ body {
 
 .navbar {
     border-radius: 0;
+    box-shadow: 0px 2px 5px rgba(100, 100, 100, 0.7);
+    flex: 0 0 auto;
+    height: 50px;
     margin-bottom: 0;
+    position: fixed;
+    width: 100%;
+    z-index: 1;
 }
 
 .navbar-text {
@@ -389,9 +391,11 @@ iframe {
 }
 
 .loading {
+  align-items: center;
+  background: transparent;
   display: flex;
   justify-content: center;
-  align-items: center;
+  margin: 55px 0 5px;
 }
 
 .versionista-info {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1,6 +1,11 @@
 @import './diff.css';
 
 /* ===== Global ===== */
+html, body, #web-monitoring-ui-root, #web-monitoring-ui-root > div,
+#application, .container-page-view, .change-view, .side-by-side-render {
+  height: 100%
+}
+
 body {
     background: #136a8a;
     background: linear-gradient(45deg, #136a8a, #267871);
@@ -18,7 +23,8 @@ body {
 }
 
 .container-page-view {
-    padding: 15px;
+  overflow: scroll;
+  padding: 15px;
 }
 
 /* ===== Nav Bar ===== */

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1,14 +1,41 @@
 @import './diff.css';
 
 /* ===== Global ===== */
-html, body, #web-monitoring-ui-root, #web-monitoring-ui-root > div,
-#application, .container-page-view, .change-view, .side-by-side-render {
+html, #web-monitoring-ui-root, #web-monitoring-ui-root > div {
   height: 100%
+}
+
+#application {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+}
+
+.navbar {
+  flex: 0 0 auto;
+}
+
+.container-page-view {
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: column;
+  padding: 15px;
+}
+
+.container-page-view > .row, .versionista-info, .version-selector {
+  flex: 0 0 auto;
+}
+
+.change-view {
+  flex: 1 0 auto;
+  display: flex;
+  flex-direction: column;
 }
 
 body {
     background: #136a8a;
     background: linear-gradient(45deg, #136a8a, #267871);
+    height: 100%;
 }
 
 .fa {
@@ -20,11 +47,6 @@ body {
     background: white;
     color: #444;
     margin: 5px 0 ;
-}
-
-.container-page-view {
-  overflow: scroll;
-  padding: 15px;
 }
 
 /* ===== Nav Bar ===== */

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -35,7 +35,19 @@ body {
 .container-list-view, .container-page-view {
     background: white;
     color: #444;
-    margin: 55px 0 5px;
+    margin: 56px 0 5px;
+}
+
+@media (max-width: 767px) {
+  .container-list-view, .container-page-view {
+    margin: 63px 0 5px;
+  }
+}
+
+@media (max-width: 571px) {
+  .container-list-view, .container-page-view {
+    margin: 83px 0 5px;
+  }
 }
 
 .container-page-view {
@@ -89,7 +101,6 @@ body {
     border-radius: 0;
     box-shadow: 0px 2px 5px rgba(100, 100, 100, 0.7);
     flex: 0 0 auto;
-    height: 50px;
     margin-bottom: 0;
     position: fixed;
     width: 100%;
@@ -395,6 +406,9 @@ iframe {
   background: transparent;
   display: flex;
   justify-content: center;
+}
+
+#application > .loading {
   margin: 55px 0 5px;
 }
 


### PR DESCRIPTION
Fixes #134 

Went with the easy solution to use css to make `change-view` full height, so that diffs extend while zoomed out. Seems like giving all parent elements `height: 100%` was enough without flexbox.

