### PR TITLE
update URL to staging API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # If you are developing the API locally, set this to the URL of your local web-monitoring-db instance
-WEB_MONITORING_DB_URL=https://web-monitoring-db-staging.herokuapp.com
+WEB_MONITORING_DB_URL=https://api-staging.monitoring.envirodatagov.org
 
 # Redirect all HTTP requests to https (you probably want this off in development)
 # FORCE_SSL=true


### PR DESCRIPTION
Fixes #149 
Updates the db url to point to our staging API

WEB_MONITORING_DB_URL=https://api-staging.monitoring.envirodatagov.org

(This was a small fix, mostly to confirm that I have the correct permissions and workflow.)