### PR TITLE
Add “highlighted rendered” diff

### DIFF
--- a/src/components/__tests__/sandboxed-html.jsx
+++ b/src/components/__tests__/sandboxed-html.jsx
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+import SandboxedHtml from '../sandboxed-html';
+
+describe('sandboxed-html', () => {
+  it('renders an iframe with a sandbox attribute', () => {
+    const sandbox = shallow(<SandboxedHtml />);
+    const frame = sandbox.find('iframe').first();
+    expect(frame).toBeDefined();
+    expect(frame.props().sandbox).toBeTruthy();
+  });
+
+  it('sets a <base> element for `baseUrl`', () => {
+    const source = `<!doctype html>
+      <html>
+        <head><title>Whatever</title></head>
+        <body>Hello!</body>
+      </html>`;
+
+    const sandbox = mount(<SandboxedHtml baseUrl="http://example.com" html={source} />);
+    const frame = sandbox.find('iframe').first().getDOMNode();
+    expect(frame.getAttribute('srcdoc')).toMatch(/<base\s+href="http:\/\/example\.com"/ig);
+  });
+
+  it('transforms the html with the `transform` prop', () => {
+    const source = `<!doctype html>
+      <html>
+        <head><title>Whatever</title></head>
+        <body>Hello!</body>
+      </html>`;
+
+    const transform = document => {
+      document.body.appendChild(document.createTextNode('Transformed!'));
+      return document;
+    };
+
+    const sandbox = mount(<SandboxedHtml html={source} transform={transform} />);
+    const frame = sandbox.find('iframe').first().getDOMNode();
+    expect(frame.getAttribute('srcdoc')).toMatch(/<body>Hello![\n\s]*Transformed!/ig);
+  });
+});

--- a/src/components/diff-view.jsx
+++ b/src/components/diff-view.jsx
@@ -5,6 +5,7 @@ import {diffTypes} from '../constants/diff-types';
 import Loading from './loading';
 
 import HighlightedTextDiff from './highlighted-text-diff';
+import InlineRenderedDiff from './inline-rendered-diff';
 import SideBySideRenderedDiff from './side-by-side-rendered-diff';
 import ChangesOnlyDiff from './changes-only-diff';
 
@@ -72,6 +73,10 @@ export default class DiffView extends React.Component {
     // in the future (e.g. inline vs. side-by-side text), we need a better
     // way to ensure we use the correct rendering and avoid race conditions
     switch (diffType) {
+    case diffTypes.HIGHLIGHTED_RENDERED.value:
+      return (
+        <InlineRenderedDiff diff={diff} page={this.props.page} />
+      );
     case diffTypes.SIDE_BY_SIDE_RENDERED.value:
       return (
         <SideBySideRenderedDiff diff={diff} page={this.props.page} />

--- a/src/components/inline-rendered-diff.jsx
+++ b/src/components/inline-rendered-diff.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+
+/**
+ * @typedef {Object} InlineRenderedDiffProps
+ * @property {Diff} diff The diff to render
+ * @property {Page} page The page this diff pertains to
+ */
+
+/**
+ * Display two versions of a page with their changes inline together.
+ *
+ * @class InlineRenderedDiff
+ * @extends {React.Component}
+ * @params {InlineRenderedDiffProps} props
+ */
+export default class InlineRenderedDiff extends React.Component {
+  constructor (props) {
+    super(props);
+    this.frame = null;
+  }
+
+  render () {
+    if (!this.props) {
+      return null;
+    }
+
+    return (
+      <div className="inline-render">
+        <iframe sandbox="allow-forms allow-scripts" ref={frame => this.frame = frame} />
+      </div>
+    );
+  }
+
+  /**
+     * @param {InlineRenderedDiffProps} nextProps
+     * @param {Object} nextState
+     * @returns {boolean}
+     */
+  shouldComponentUpdate (nextProps, nextState) {
+    return nextProps.diff.from_version_id !== this.props.diff.from_version_id
+      || nextProps.diff.to_version_id !== this.props.diff.to_version_id;
+  }
+
+  componentDidMount () {
+    this._updateContent();
+  }
+
+  componentDidUpdate () {
+    this._updateContent();
+  }
+
+  _updateContent () {
+    const raw_source = this.props.diff.content.diff;
+
+    this.frame.setAttribute(
+      'srcdoc',
+      renderableSource(raw_source, this.props.page));
+  }
+}
+
+/**
+ * Create renderable HTML source code from the raw HTML source of the diff.
+ *
+ * @param {string} source Full diff source code
+ * @param {Page} page The page that is being diffed
+ * @param {string} viewType Either `additions` or `removals`
+ */
+function renderableSource (source, page, viewType) {
+  const parser = new DOMParser();
+  const newDocument = parser.parseFromString(source, 'text/html');
+  renderableDocument(newDocument, page);
+  const prefix = source.match(/^[^]*?<html/ig)[0];
+  return prefix + newDocument.documentElement.outerHTML.slice(5);
+}
+
+/**
+ * Process HTML document so that it renders nicely. This includes things like
+ * adding a `<base>` tag so subresources are properly fetched.
+ *
+ * @param {HTMLDocument} sourceDocument
+ * @param {Page} page
+ * @returns {HTMLDocument}
+ */
+function renderableDocument (sourceDocument, page) {
+  const base = sourceDocument.createElement('base');
+  base.href = page.url;
+  // <meta charset> tags don't work unless they are first, so if one is
+  // present, modify <head> content *after* it.
+  const charsetElement = sourceDocument.querySelector('meta[charset]');
+  if (charsetElement) {
+    charsetElement.insertAdjacentElement('afterend', base);
+  }
+  else {
+    sourceDocument.head.insertAdjacentElement('afterbegin', base);
+  }
+
+  // TODO: remove this block when new diff (indicated by presence of
+  // wm-diff-style) is fully deployed.
+  if (!sourceDocument.getElementById('wm-diff-style')) {
+    // The differ currently HTML-encodes the source code in these elements :\
+    // https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/94
+    sourceDocument.querySelectorAll('style, script').forEach(element => {
+      element.textContent = element.textContent
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#(x?)([0-9a-f]+);/ig, (text, hex, value) => {
+          const code = parseInt(value, hex ? 16 : 10);
+          return String.fromCharCode(code);
+        });
+    });
+  }
+
+  return sourceDocument;
+}

--- a/src/components/inline-rendered-diff.jsx
+++ b/src/components/inline-rendered-diff.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import SandboxedHtml from './sandboxed-html';
 
 /**
  * @typedef {Object} InlineRenderedDiffProps
@@ -14,103 +15,7 @@ import React from 'react';
  * @params {InlineRenderedDiffProps} props
  */
 export default class InlineRenderedDiff extends React.Component {
-  constructor (props) {
-    super(props);
-    this.frame = null;
-  }
-
   render () {
-    if (!this.props) {
-      return null;
-    }
-
-    return (
-      <div className="inline-render">
-        <iframe sandbox="allow-forms allow-scripts" ref={frame => this.frame = frame} />
-      </div>
-    );
+    return <SandboxedHtml html={this.props.diff.content.diff} baseUrl={this.props.page.url} />;
   }
-
-  /**
-     * @param {InlineRenderedDiffProps} nextProps
-     * @param {Object} nextState
-     * @returns {boolean}
-     */
-  shouldComponentUpdate (nextProps, nextState) {
-    return nextProps.diff.from_version_id !== this.props.diff.from_version_id
-      || nextProps.diff.to_version_id !== this.props.diff.to_version_id;
-  }
-
-  componentDidMount () {
-    this._updateContent();
-  }
-
-  componentDidUpdate () {
-    this._updateContent();
-  }
-
-  _updateContent () {
-    const raw_source = this.props.diff.content.diff;
-
-    this.frame.setAttribute(
-      'srcdoc',
-      renderableSource(raw_source, this.props.page));
-  }
-}
-
-/**
- * Create renderable HTML source code from the raw HTML source of the diff.
- *
- * @param {string} source Full diff source code
- * @param {Page} page The page that is being diffed
- * @param {string} viewType Either `additions` or `removals`
- */
-function renderableSource (source, page, viewType) {
-  const parser = new DOMParser();
-  const newDocument = parser.parseFromString(source, 'text/html');
-  renderableDocument(newDocument, page);
-  const prefix = source.match(/^[^]*?<html/ig)[0];
-  return prefix + newDocument.documentElement.outerHTML.slice(5);
-}
-
-/**
- * Process HTML document so that it renders nicely. This includes things like
- * adding a `<base>` tag so subresources are properly fetched.
- *
- * @param {HTMLDocument} sourceDocument
- * @param {Page} page
- * @returns {HTMLDocument}
- */
-function renderableDocument (sourceDocument, page) {
-  const base = sourceDocument.createElement('base');
-  base.href = page.url;
-  // <meta charset> tags don't work unless they are first, so if one is
-  // present, modify <head> content *after* it.
-  const charsetElement = sourceDocument.querySelector('meta[charset]');
-  if (charsetElement) {
-    charsetElement.insertAdjacentElement('afterend', base);
-  }
-  else {
-    sourceDocument.head.insertAdjacentElement('afterbegin', base);
-  }
-
-  // TODO: remove this block when new diff (indicated by presence of
-  // wm-diff-style) is fully deployed.
-  if (!sourceDocument.getElementById('wm-diff-style')) {
-    // The differ currently HTML-encodes the source code in these elements :\
-    // https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/94
-    sourceDocument.querySelectorAll('style, script').forEach(element => {
-      element.textContent = element.textContent
-        .replace(/&amp;/g, '&')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&quot;/g, '"')
-        .replace(/&#(x?)([0-9a-f]+);/ig, (text, hex, value) => {
-          const code = parseInt(value, hex ? 16 : 10);
-          return String.fromCharCode(code);
-        });
-    });
-  }
-
-  return sourceDocument;
 }

--- a/src/components/inline-rendered-diff.jsx
+++ b/src/components/inline-rendered-diff.jsx
@@ -16,6 +16,10 @@ import SandboxedHtml from './sandboxed-html';
  */
 export default class InlineRenderedDiff extends React.Component {
   render () {
-    return <SandboxedHtml html={this.props.diff.content.diff} baseUrl={this.props.page.url} />;
+    return (
+      <div className="inline-render">
+        <SandboxedHtml html={this.props.diff.content.diff} baseUrl={this.props.page.url} />
+      </div>
+    );
   }
 }

--- a/src/components/sandboxed-html.jsx
+++ b/src/components/sandboxed-html.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+
+/**
+ * @typedef {Object} SandboxedHtmlProps
+ * @property {string} html The HTML source or document to render
+ * @property {string} [baseUrl] A base URL to set for the view
+ * @property {(HTMLDocument) => HTMLDocument} [transform] An optional transform
+ *           function to apply to the document before rendering.
+ */
+
+/**
+ * Display HTML source code or document in a sandboxed frame.
+ *
+ * @class SandboxedHtml
+ * @extends {React.Component}
+ * @params {SandboxedHtmlProps} props
+ */
+export default class SandboxedHtml extends React.PureComponent {
+  constructor (props) {
+    super(props);
+    this._frame = null;
+  }
+
+  componentDidMount () {
+    this._updateContent();
+  }
+
+  componentDidUpdate () {
+    this._updateContent();
+  }
+
+  render () {
+    return <iframe
+      sandbox="allow-forms allow-scripts"
+      ref={frame => this._frame = frame}
+    />;
+  }
+
+  _updateContent () {
+    let source = transformSource(this.props.html, document => {
+      if (this.props.transform) {
+        document = this.props.transform(document) || document;
+      }
+      return setDocumentBase(document, this.props.baseUrl);
+    });
+
+    this._frame.setAttribute('srcdoc', source);
+  }
+}
+
+/**
+ * Run a transform function against an HTML source code string or document and
+ * return the resulting HTML source code.
+ * @private
+ *
+ * @param {string} source
+ * @param {(HTMLDocument) => HTMLDocument} transformer
+ * @returns {string}
+ */
+function transformSource (source, transformer) {
+  const parser = new DOMParser();
+  let newDocument = parser.parseFromString(source, 'text/html');
+  newDocument = transformer(newDocument);
+  return `<!doctype html>\n${newDocument.documentElement.outerHTML}`;
+}
+
+/**
+ * Set the `base` URL for a document, which alters where links, images, etc.
+ * point to if they do not include a domain name.
+ * @private
+ *
+ * @param {HTMLDocument} document
+ * @param {string} baseUrl
+ * @returns {HTMLDocument}
+ */
+function setDocumentBase (document, baseUrl) {
+  if (baseUrl) {
+    const base = document.querySelector('base')
+      || document.createElement('base');
+    base.href = baseUrl;
+
+    // <meta charset> tags don't work unless they are first, so if one is
+    // present, modify <head> content *after* it.
+    const charsetElement = document.querySelector('meta[charset]');
+    let beforeElement = document.head.firstChild;
+    if (charsetElement) {
+      beforeElement = charsetElement.nextSibling;
+    }
+    if (beforeElement) {
+      beforeElement.parentNode.insertBefore(base, beforeElement);
+    }
+    else {
+      document.head.appendChild(base);
+    }
+  }
+
+  return document;
+}

--- a/src/components/side-by-side-rendered-diff.jsx
+++ b/src/components/side-by-side-rendered-diff.jsx
@@ -1,4 +1,8 @@
 import React from 'react';
+import SandboxedHtml from './sandboxed-html';
+
+const showRemovals = showType.bind(null, 'removals');
+const showAdditions = showType.bind(null, 'additions');
 
 /**
  * @typedef {Object} SideBySideRenderedDiffProps
@@ -14,142 +18,39 @@ import React from 'react';
  * @params {SideBySideRenderedDiffProps} props
  */
 export default class SideBySideRenderedDiff extends React.Component {
-  constructor (props) {
-    super(props);
-    this.frameA = null;
-    this.frameB = null;
-  }
-
   render () {
-    if (!this.props) {
-      return null;
-    }
-
     return (
       <div className="side-by-side-render">
-        <iframe sandbox="allow-forms allow-scripts" ref={frame => this.frameA = frame} />
-        <iframe sandbox="allow-forms allow-scripts" ref={frame => this.frameB = frame} />
+        <SandboxedHtml
+          html={this.props.diff.content.diff}
+          baseUrl={this.props.page.url}
+          transform={showRemovals}
+        />
+        <SandboxedHtml
+          html={this.props.diff.content.diff}
+          baseUrl={this.props.page.url}
+          transform={showAdditions}
+        />
       </div>
     );
   }
-
-  /**
-     * @param {SideBySideRenderedDiffProps} nextProps
-     * @param {Object} nextState
-     * @returns {boolean}
-     */
-  shouldComponentUpdate (nextProps, nextState) {
-    return nextProps.diff.from_version_id !== this.props.diff.from_version_id
-      || nextProps.diff.to_version_id !== this.props.diff.to_version_id;
-  }
-
-  componentDidMount () {
-    this._updateContent();
-  }
-
-  componentDidUpdate () {
-    this._updateContent();
-  }
-
-  _updateContent () {
-    const raw_source = this.props.diff.content.diff;
-
-    this.frameA.setAttribute(
-      'srcdoc',
-      createChangedSource(raw_source, this.props.page, 'removals'));
-    this.frameB.setAttribute(
-      'srcdoc',
-      createChangedSource(raw_source, this.props.page, 'additions'));
-  }
 }
 
-/**
- * Create renderable HTML source code rendering either the added or removed
- * parts of the page from an HTML diff representing the full change between
- * two versions.
- *
- * @param {string} source Full diff source code
- * @param {Page} page The page that is being diffed
- * @param {string} viewType Either `additions` or `removals`
- */
-function createChangedSource (source, page, viewType) {
+function showType (viewType, sourceDocument) {
+  // Show correct version of document `<head>`
+  if (viewType !== 'additions') {
+    const oldHead = sourceDocument.getElementById('wm-diff-old-head').content;
+    const styling = sourceDocument.getElementById('wm-diff-style');
+    const titleDiff = sourceDocument.querySelector('meta[name="wm-diff-title"]');
+    sourceDocument.head.innerHTML = '';
+    sourceDocument.head.appendChild(oldHead);
+    sourceDocument.head.appendChild(styling);
+    sourceDocument.head.appendChild(titleDiff);
+  }
+
   const elementToRemove = viewType === 'additions' ? 'del' : 'ins';
-
-  let newSource = source;
-  // TODO: remove this when new diffs are fully deployed; they no longer have
-  // `<ins>/<del>` in the `<head>`.
-  const hasOldHeadTemplate = !!source.match(/<template id="wm-diff-old-head"/i);
-  if (!hasOldHeadTemplate) {
-    // Remove <ins/del> in <head> before parsing; parsing will throw them out
-    // but keep their contents. That could leave us with <link> or <script>
-    // elements that should have been removed.
-    newSource = source.replace(/<head[^]*<\/head>/i, head => {
-      return head.replace(
-        new RegExp(`<${elementToRemove}[^>]*>[^]*?</${elementToRemove}>`, 'ig'),
-        '');
-    });
-  }
-
-  const parser = new DOMParser();
-  const newDocument = parser.parseFromString(newSource, 'text/html');
-  // Rebuild <head> with contents of old version's `<head>`
-  if (hasOldHeadTemplate && viewType !== 'additions') {
-    const oldHead = newDocument.getElementById('wm-diff-old-head').content;
-    const styling = newDocument.getElementById('wm-diff-style');
-    const titleDiff = newDocument.querySelector('meta[name="wm-diff-title"]');
-    newDocument.head.innerHTML = '';
-    newDocument.head.appendChild(oldHead);
-    newDocument.head.appendChild(styling);
-    newDocument.head.appendChild(titleDiff);
-  }
-  removeChangeElements(elementToRemove, newDocument);
-  renderableDocument(newDocument, page);
-  activateInertChangeElements(viewType, newDocument);
-
-  const prefix = source.match(/^[^]*?<html/ig)[0];
-  newSource = prefix + newDocument.documentElement.outerHTML.slice(5);
-
-  return newSource;
-}
-
-/**
- * Process HTML document so that it renders nicely. This includes things like
- * adding a `<base>` tag so subresources are properly fetched.
- *
- * @param {HTMLDocument} sourceDocument
- * @param {Page} page
- * @returns {HTMLDocument}
- */
-function renderableDocument (sourceDocument, page) {
-  const base = sourceDocument.createElement('base');
-  base.href = page.url;
-  // <meta charset> tags don't work unless they are first, so if one is
-  // present, modify <head> content *after* it.
-  const charsetElement = sourceDocument.querySelector('meta[charset]');
-  if (charsetElement) {
-    charsetElement.insertAdjacentElement('afterend', base);
-  }
-  else {
-    sourceDocument.head.insertAdjacentElement('afterbegin', base);
-  }
-
-  // TODO: remove this block when new diff (indicated by presence of
-  // wm-diff-style) is fully deployed.
-  if (!sourceDocument.getElementById('wm-diff-style')) {
-    // The differ currently HTML-encodes the source code in these elements :\
-    // https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/94
-    sourceDocument.querySelectorAll('style, script').forEach(element => {
-      element.textContent = element.textContent
-        .replace(/&amp;/g, '&')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&quot;/g, '"')
-        .replace(/&#(x?)([0-9a-f]+);/ig, (text, hex, value) => {
-          const code = parseInt(value, hex ? 16 : 10);
-          return String.fromCharCode(code);
-        });
-    });
-  }
+  removeChangeElements(elementToRemove, sourceDocument);
+  activateInertChangeElements(viewType, sourceDocument);
 
   return sourceDocument;
 }

--- a/src/constants/diff-types.js
+++ b/src/constants/diff-types.js
@@ -9,7 +9,7 @@ export const diffTypes = {
   },
   HIGHLIGHTED_RENDERED: {
     description: 'Highlighted Rendered',
-    diffService: 'TODO',
+    diffService: 'html_visual',
   },
   SIDE_BY_SIDE_RENDERED: {
     description: 'Side-by-Side Rendered',

--- a/src/css/diff.css
+++ b/src/css/diff.css
@@ -5,12 +5,14 @@ ins {
     background-color: lightgreen !important;
 }
 
-.side-by-side-render {
+.side-by-side-render,
+.inline-render {
     display: flex;
     flex: 1 0 auto;
 }
 
-.side-by-side-render > iframe {
+.side-by-side-render > iframe,
+.inline-render > iframe {
     border: 1px solid #ccc;
     border-radius: 2px;
     width: 100%;


### PR DESCRIPTION
The improved HTML differ over on the processing side finally returns pages that are safe to render without first ripping them apart, so we can now implement a visual diff with all the changes inline together (instead of side-by-side).

This is pretty much the same as `SideBySideRendered`, but only has one frame and doesn't need to do as much processing of the HTML source code.

Prompted by this change over on #156: https://github.com/edgi-govdata-archiving/web-monitoring-ui/pull/156#discussion_r153897004