### PR TITLE
Add unbelievably terrible search

### DIFF
--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -75,7 +75,7 @@ export default class WebMonitoringUi extends React.Component {
 
   search (query) {
     this.setState({search: query});
-    this.loadPages('pages');
+    this.loadPages(this.state.pageFilter);
   }
 
   /**

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -37,6 +37,7 @@ export default class WebMonitoringUi extends React.Component {
       isLoading: true,
       pageFilter: '', // keeps track of which set of pages we are looking at
       pages: null,
+      search: null,
       showLogin: false,
       user: null,
     };
@@ -46,6 +47,7 @@ export default class WebMonitoringUi extends React.Component {
     this.logOut = this.logOut.bind(this);
     this.loadPages = this.loadPages.bind(this);
     this.setPageFilter = this.setPageFilter.bind(this);
+    this.search = this.search.bind(this);
   }
 
   setPageFilter (filter) {
@@ -71,6 +73,11 @@ export default class WebMonitoringUi extends React.Component {
     this.loadPages('pages');
   }
 
+  search (query) {
+    this.setState({search: query});
+    this.loadPages('pages');
+  }
+
   /**
    * Load pages depending on whether we want all pages or assigned pages.
    * @private
@@ -87,7 +94,7 @@ export default class WebMonitoringUi extends React.Component {
           return Promise.reject(new Error('You must be logged in to view pages'));
         }
 
-        const query = {include_latest: true};
+        const query = Object.assign({include_latest: true}, this.state.search);
         if (pageFilter === 'assignedPages') {
           return localApi.getPagesForUser(api.userData.email, null, query);
         }
@@ -137,6 +144,7 @@ export default class WebMonitoringUi extends React.Component {
           {...routeProps}
           pages={pages}
           user={this.state.user}
+          onSearch={this.search}
         />;
       };
     };

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -129,6 +129,18 @@ body {
     background-color: #EEE;
 }
 
+.search-bar {
+  border-bottom: 1px solid #ccc;
+  margin-bottom: 0.5em;
+}
+
+.search-bar input {
+  width: 100%;
+  border: none;
+  font-size: 1.25em;
+  padding: 0.5em 15px;
+}
+
 /* ===== Page Detail View ===== */
 .page-title {
     font-size: 1.5em;


### PR DESCRIPTION
This is not very good and should probably be totally rewritten, but I’m realizing just having *something* for this would be really useful. Pertains to #64 but is in no a way a well-thought-through or even full solution.

This lets you search by URL only (though you can include `*` as a wildcard anywhere in the URL).

Depends on #164.

![screen shot 2017-12-18 at 2 19 51 pm](https://user-images.githubusercontent.com/74178/34130953-ac9509b6-e3fe-11e7-8b0e-b1b76095e3bb.png)