### PR TITLE
Remove versionista links from list view 

### DIFF
--- a/src/components/change-view.jsx
+++ b/src/components/change-view.jsx
@@ -57,7 +57,6 @@ export default class ChangeView extends React.Component {
     this.handleFromVersionChange = this.handleFromVersionChange.bind(this);
     this.handleToVersionChange = this.handleToVersionChange.bind(this);
     this.handleDiffTypeChange = this.handleDiffTypeChange.bind(this);
-    this.handleLatestToBaseChange = this.handleLatestToBaseChange.bind(this);
     this._toggleCollapsedView = this._toggleCollapsedView.bind(this);
     this._annotateChange = this._annotateChange.bind(this);
     this._updateAnnotation = this._updateAnnotation.bind(this);

--- a/src/components/change-view.jsx
+++ b/src/components/change-view.jsx
@@ -88,15 +88,13 @@ export default class ChangeView extends React.Component {
   handleDiffTypeChange (diffType) {
     this.setState({diffType});
   }
+
   handleFromVersionChange (version) {
     this._changeSelectedVersions(version, null);
   }
+
   handleToVersionChange (version) {
     this._changeSelectedVersions(null, version);
-  }
-  handleLatestToBaseChange () {
-    const {versions} = this.props.page;
-    this._changeSelectedVersions(versions[versions.length - 1], versions[0]);
   }
 
   render () {
@@ -119,7 +117,6 @@ export default class ChangeView extends React.Component {
         {userCanAnnotate ? this.renderSubmission() : null}
         <div className="comparison-controls">
           <VersionistaInfo versions={this.props.page.versions} from={this.props.from} to={this.props.to}/>
-          <button className="btn-link" onClick={this.handleLatestToBaseChange} type="button">Latest to Base</button>
         </div>
         {this.renderVersionSelector(page)}
         <DiffView page={page} diffType={this.state.diffType} a={this.props.from} b={this.props.to} />

--- a/src/components/change-view.jsx
+++ b/src/components/change-view.jsx
@@ -114,9 +114,7 @@ export default class ChangeView extends React.Component {
     return (
       <div className="change-view">
         {userCanAnnotate ? this.renderSubmission() : null}
-        <div className="comparison-controls">
-          <VersionistaInfo versions={this.props.page.versions} from={this.props.from} to={this.props.to}/>
-        </div>
+        <VersionistaInfo versions={this.props.page.versions} from={this.props.from} to={this.props.to}/>
         {this.renderVersionSelector(page)}
         <DiffView page={page} diffType={this.state.diffType} a={this.props.from} b={this.props.to} />
       </div>

--- a/src/components/change-view.jsx
+++ b/src/components/change-view.jsx
@@ -57,6 +57,7 @@ export default class ChangeView extends React.Component {
     this.handleFromVersionChange = this.handleFromVersionChange.bind(this);
     this.handleToVersionChange = this.handleToVersionChange.bind(this);
     this.handleDiffTypeChange = this.handleDiffTypeChange.bind(this);
+    this.handleLatestToBaseChange = this.handleLatestToBaseChange.bind(this);
     this._toggleCollapsedView = this._toggleCollapsedView.bind(this);
     this._annotateChange = this._annotateChange.bind(this);
     this._updateAnnotation = this._updateAnnotation.bind(this);
@@ -93,6 +94,10 @@ export default class ChangeView extends React.Component {
   handleToVersionChange (version) {
     this._changeSelectedVersions(null, version);
   }
+  handleLatestToBaseChange () {
+    const {versions} = this.props.page;
+    this._changeSelectedVersions(versions[versions.length - 1], versions[0]);
+  }
 
   render () {
     const { page } = this.props;
@@ -112,7 +117,10 @@ export default class ChangeView extends React.Component {
     return (
       <div className="change-view">
         {userCanAnnotate ? this.renderSubmission() : null}
-        <VersionistaInfo versions={this.props.page.versions} from={this.props.from} to={this.props.to}/>
+        <div className="comparison-controls">
+          <VersionistaInfo versions={this.props.page.versions} from={this.props.from} to={this.props.to}/>
+          <button className="btn-link" onClick={this.handleLatestToBaseChange} type="button">Latest to Base</button>
+        </div>
         {this.renderVersionSelector(page)}
         <DiffView page={page} diffType={this.state.diffType} a={this.props.from} b={this.props.to} />
       </div>

--- a/src/components/page-list.jsx
+++ b/src/components/page-list.jsx
@@ -1,3 +1,4 @@
+import {dateFormatter} from '../scripts/formatters';
 import React from 'react';
 import Loading from './loading';
 
@@ -41,54 +42,27 @@ export default class PageList extends React.Component {
   renderHeader () {
     return (
       <tr>
-        <th>ID</th>
-        <th>Output Date</th>
+        <th>Capture Date</th>
         <th>Site</th>
         <th>Page Name</th>
         <th>URL</th>
-        <th>Page View URL</th>
-        <th>Last Two</th>
-        <th>Latest to Base</th>
       </tr>
     );
   }
 
   renderRow (record) {
     const version = record.latest;
-    let versionistaData;
-    if (version.source_type === 'versionista') {
-      versionistaData = version.source_metadata;
-    }
-
-    const diffWithPrevious = versionistaData && this.renderDiffLink(versionistaData.diff_with_previous_url);
-    const diffWithFirst = versionistaData && this.renderDiffLink(versionistaData.diff_with_first_url);
-
     const onClick = this.didClickRow.bind(this, record);
-
-    const shortUrl = `${record.url.substr(0, 20)}…`;
-    const rawContentPath = versionistaData && versionistaData.url.replace(/^\w+:\/\/[^/]+\//, '');
 
     // TODO: click handling
     return (
       <tr key={record.uuid} onClick={onClick}>
-        <td>{record.uuid}</td>
-        <td>{record.latest.capture_time.toISOString()}</td>
+        <td>{dateFormatter.format(record.latest.capture_time)}</td>
         <td>{record.site}</td>
         <td>{record.title}</td>
-        <td><a href={record.url} target="_blank" rel="noopener">{shortUrl}</a></td>
-        <td><a href={versionistaData && versionistaData.url} target="_blank" rel="noopener">{rawContentPath}</a></td>
-        <td>{diffWithPrevious}</td>
-        <td>{diffWithFirst}</td>
+        <td><a href={record.url} target="_blank" rel="noopener">{record.url}</a></td>
       </tr>
     );
-  }
-
-  renderDiffLink (url) {
-    if (url) {
-      return <a href={url} target="_blank">{url.substr(-15)}</a>;
-    }
-
-    return <em>[Initial Version]</em>;
   }
 
   didClickRow (page, event) {

--- a/src/components/page-list.jsx
+++ b/src/components/page-list.jsx
@@ -25,7 +25,7 @@ export default class PageList extends React.Component {
       <div className="container-fluid container-list-view">
         <div className="row">
           <div className="col-md-12">
-            <table className="table">
+            <table className="container-list-view--list table">
               <thead>
                 {this.renderHeader()}
               </thead>

--- a/src/components/page-list.jsx
+++ b/src/components/page-list.jsx
@@ -25,7 +25,7 @@ export default class PageList extends React.Component {
       <div className="container-fluid container-list-view">
         <div className="row">
           <div className="col-md-12">
-            <table className="container-list-view--list table">
+            <table className="container-list-view__list table">
               <thead>
                 {this.renderHeader()}
               </thead>
@@ -42,10 +42,10 @@ export default class PageList extends React.Component {
   renderHeader () {
     return (
       <tr>
-        <th>Capture Date</th>
-        <th>Site</th>
-        <th>Page Name</th>
-        <th>URL</th>
+        <th className="list__header--capture-date">Capture Date</th>
+        <th className="list__header--site">Site</th>
+        <th className="list__header--page-name">Page Name</th>
+        <th className="list__header--url">URL</th>
       </tr>
     );
   }

--- a/src/components/page-list.jsx
+++ b/src/components/page-list.jsx
@@ -25,7 +25,7 @@ export default class PageList extends React.Component {
       <div className="container-fluid container-list-view">
         <div className="row">
           <div className="col-md-12">
-            <table className="container-list-view__list table">
+            <table className="page-list table">
               <thead>
                 {this.renderHeader()}
               </thead>
@@ -42,10 +42,10 @@ export default class PageList extends React.Component {
   renderHeader () {
     return (
       <tr>
-        <th className="list__header--capture-date">Capture Date</th>
-        <th className="list__header--site">Site</th>
-        <th className="list__header--page-name">Page Name</th>
-        <th className="list__header--url">URL</th>
+        <th data-name="capture-date">Capture Date</th>
+        <th data-name="site">Site</th>
+        <th data-name="page-name">Page Name</th>
+        <th data-name="url">URL</th>
       </tr>
     );
   }

--- a/src/components/page-list.jsx
+++ b/src/components/page-list.jsx
@@ -51,7 +51,6 @@ export default class PageList extends React.Component {
   }
 
   renderRow (record) {
-    const version = record.latest;
     const onClick = this.didClickRow.bind(this, record);
 
     // TODO: click handling

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -129,6 +129,31 @@ body {
     background-color: #EEE;
 }
 
+.table {
+  table-layout: fixed;
+}
+.table tr > td:first-child,
+.table tr > th:first-child {
+  width: 12%;
+}
+.table tr > td:nth-child(2),
+.table tr > th:nth-child(2)  {
+  width: 15%;
+}
+.table tr > td:nth-child(3),
+.table tr > th:nth-child(3) {
+  width: 33%;
+}
+
+.table tr > td:nth-child(4),
+.table tr > th:nth-child(4) {
+  width: 40%;
+}
+.table tr > td:nth-child(4) {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
 /* ===== Page Detail View ===== */
 .page-title {
     font-size: 1.5em;

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -121,37 +121,37 @@ body {
 }
 
 /* ===== List View ===== */
-.container-list-view tbody tr {
-    cursor: pointer;
+.container-list-view__list tbody tr {
+  cursor: pointer;
 }
 
-.container-list-view tbody tr:hover {
-    background-color: #EEE;
+.container-list-view__list tbody tr:hover {
+  background-color: #EEE;
 }
 
-.container-list-view--list {
+.container-list-view__list {
   table-layout: fixed;
 }
 
-.container-list-view--list tr > td:first-child {
+.container-list-view__list td {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
+.list__header--capture-date {
   width: 12%;
 }
 
-.container-list-view--list tr > td:nth-child(2)  {
+.list__header--site  {
   width: 15%;
 }
 
-.container-list-view--list tr > td:nth-child(3) {
+.list__header--page-name {
   width: 33%;
 }
 
-.container-list-view--list tr > td:nth-child(4) {
+.list__header--url {
   width: 40%;
-}
-
-.container-list-view--list tr > td {
-  overflow-wrap: break-word;
-  word-wrap: break-word;
 }
 
 /* ===== Page Detail View ===== */

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -132,24 +132,24 @@ body {
 .table {
   table-layout: fixed;
 }
-.table tr > td:first-child,
-.table tr > th:first-child {
+
+.table tr > td:first-child {
   width: 12%;
 }
-.table tr > td:nth-child(2),
-.table tr > th:nth-child(2)  {
+
+.table tr > td:nth-child(2)  {
   width: 15%;
 }
-.table tr > td:nth-child(3),
-.table tr > th:nth-child(3) {
+
+.table tr > td:nth-child(3) {
   width: 33%;
 }
 
-.table tr > td:nth-child(4),
-.table tr > th:nth-child(4) {
+.table tr > td:nth-child(4) {
   width: 40%;
 }
-.table tr > td:nth-child(4) {
+
+.table tr > td {
   overflow-wrap: break-word;
   word-wrap: break-word;
 }
@@ -212,6 +212,12 @@ body {
     display: inline;
     line-height: inherit;
     vertical-align: baseline;
+}
+
+.comparison-controls {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 1em;
 }
 
 /* Version Selector */
@@ -426,10 +432,6 @@ iframe {
   background: transparent;
   display: flex;
   justify-content: center;
-}
-
-.versionista-info {
-  margin-top: 1em;
 }
 
 .versionista-info i {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -121,36 +121,36 @@ body {
 }
 
 /* ===== List View ===== */
-.container-list-view__list tbody tr {
-  cursor: pointer;
-}
-
-.container-list-view__list tbody tr:hover {
-  background-color: #EEE;
-}
-
-.container-list-view__list {
+.page-list {
   table-layout: fixed;
 }
 
-.container-list-view__list td {
+.page-list tbody tr {
+  cursor: pointer;
+}
+
+.page-list tbody tr:hover {
+  background-color: #EEE;
+}
+
+.page-list td {
   overflow-wrap: break-word;
   word-wrap: break-word;
 }
 
-.list__header--capture-date {
+.page-list th[data-name="capture-date"] {
   width: 12%;
 }
 
-.list__header--site  {
+.page-list th[data-name="site"]  {
   width: 15%;
 }
 
-.list__header--page-name {
+.page-list th[data-name="page-name"] {
   width: 33%;
 }
 
-.list__header--url {
+.page-list th[data-name="url"] {
   width: 40%;
 }
 

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -214,12 +214,6 @@ body {
     vertical-align: baseline;
 }
 
-.comparison-controls {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 1em;
-}
-
 /* Version Selector */
 .version-selector {
     display: flex;
@@ -432,6 +426,10 @@ iframe {
   background: transparent;
   display: flex;
   justify-content: center;
+}
+
+.versionista-info {
+  margin-top: 1em;
 }
 
 .versionista-info i {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -129,27 +129,27 @@ body {
     background-color: #EEE;
 }
 
-.table {
+.container-list-view--list {
   table-layout: fixed;
 }
 
-.table tr > td:first-child {
+.container-list-view--list tr > td:first-child {
   width: 12%;
 }
 
-.table tr > td:nth-child(2)  {
+.container-list-view--list tr > td:nth-child(2)  {
   width: 15%;
 }
 
-.table tr > td:nth-child(3) {
+.container-list-view--list tr > td:nth-child(3) {
   width: 33%;
 }
 
-.table tr > td:nth-child(4) {
+.container-list-view--list tr > td:nth-child(4) {
   width: 40%;
 }
 
-.table tr > td {
+.container-list-view--list tr > td {
   overflow-wrap: break-word;
   word-wrap: break-word;
 }


### PR DESCRIPTION
Fixes #163 

Also, added a 'Latest to Base' button on `page-details`. 
I think we were always using the correct field for [capture time](https://github.com/edgi-govdata-archiving/web-monitoring-ui/blob/a622a24aaf42565b8a9e7bd60627baa1c7f8ee98/src/components/page-list.jsx#L60) and it was just the name of the column that was off, so unsure if `record.latest.capture_time` is what we really want.

Side note: Noticed when pointed at production api, that I'm getting `Error: Raw content is not available for version` for a lot of records on `/pages`. Can someone double-check that I'm not crazy?