### PR TITLE
Fix broken versionista links

### DIFF
--- a/server/sheet-data.js
+++ b/server/sheet-data.js
@@ -96,7 +96,7 @@ function addChangeToDictionary (data) {
     data.page.url,
     // Page View URL
     // TODO: should these all be the web-monitoring-ui URLs instead?
-    versionista ? `https://versionista.com/${versionista.site_id}/${versionista.page_id}` : '',
+    versionista ? `https://versionista.com/${versionista.site_id}/${versionista.page_id}/` : '',
     // Last Two - Side by Side
     versionista ? versionista.diff_with_previous_url : '',
     // Latest to Base - Side by Side
@@ -148,7 +148,7 @@ function addChangeToImportant (data) {
     data.page.url,
     // Page View URL
     // TODO: should these all be the web-monitoring-ui URLs instead?
-    versionista ? `https://versionista.com/${versionista.site_id}/${versionista.page_id}` : '',
+    versionista ? `https://versionista.com/${versionista.site_id}/${versionista.page_id}/` : '',
     // Last Two - Side by Side
     versionista ? versionista.diff_with_previous_url : '',
     // Latest to Base - Side by Side

--- a/src/components/__tests__/versionista-info.test.jsx
+++ b/src/components/__tests__/versionista-info.test.jsx
@@ -58,7 +58,7 @@ describe('Versionista-Info', () => {
   it('outputs link to page view if both versions are the same', () => {
     const vInfo = render(<VersionistaInfo from={from} to={from} />);
     const { attribs: { href } } = vInfo.find('a')[0];
-    expect(href).toBe('https://versionista.com/74273/6210778');
+    expect(href).toBe('https://versionista.com/74273/6210778/');
   });
 
   describe('Link tests', () => {
@@ -68,7 +68,7 @@ describe('Versionista-Info', () => {
 
       const vInfo = render(<VersionistaInfo to={to} from={from} versions={versions} />);
       const { attribs: { href } } = vInfo.find('a')[0];
-      expect(href).toBe('https://versionista.com/74273/6210778/13117888:9452489');
+      expect(href).toBe('https://versionista.com/74273/6210778/13117888:9452489/');
     });
 
     it('outputs link if `from` is first version of set of >50 versions', () => {
@@ -81,7 +81,7 @@ describe('Versionista-Info', () => {
 
       const vInfo = render(<VersionistaInfo to={to} from={from} versions={versions} />);
       const { attribs: { href } } = vInfo.find('a')[0];
-      expect(href).toBe('https://versionista.com/74273/6210778/13117888:9452489');
+      expect(href).toBe('https://versionista.com/74273/6210778/13117888:9452489/');
     });
 
     it('switches `to` and `from` to give us correct Versionista link', () => {
@@ -90,7 +90,7 @@ describe('Versionista-Info', () => {
 
       const vInfo = render(<VersionistaInfo to={from} from={to} versions={versions} />);
       const { attribs: { href } } = vInfo.find('a')[0];
-      expect(href).toBe('https://versionista.com/74273/6210778/13117888:9452489');
+      expect(href).toBe('https://versionista.com/74273/6210778/13117888:9452489/');
     });
   });
 

--- a/src/components/versionista-info.jsx
+++ b/src/components/versionista-info.jsx
@@ -50,7 +50,7 @@ export default class VersionistaInfo extends React.Component {
     } = this.props.from.source_metadata;
 
     return (
-      <a target="_blank" href={`https://versionista.com/${site_id}/${page_id}`}>
+      <a target="_blank" href={`https://versionista.com/${site_id}/${page_id}/`}>
         The selected versions are the same. View the page in Versionista. (account: {account})
       </a>
     );
@@ -92,7 +92,7 @@ export default class VersionistaInfo extends React.Component {
       <span>
         <a
           target="_blank"
-          href={`https://versionista.com/${site_id}/${page_id}/${toVersionId}:${fromVersionId}`}
+          href={`https://versionista.com/${site_id}/${page_id}/${toVersionId}:${fromVersionId}/`}
         >
           View this diff in Versionista (account: {account})
         </a>


### PR DESCRIPTION
Versionista recently changed so that `/` is required at the end of all URLs (otherwise it displays the page with the trailing part of the path removed, so `https://versionista.com/123/456` is the same as `https://versionista.com/123/`, for example). Fix our fallback Versionista links to have the trailing slash.

We’ve already updated all the analyst sheet generation logic, but I’d forgotten about the UI here.