### PR TITLE
Use regex-like symbols to get 'latest' and 'base' versions

### DIFF
--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -176,8 +176,9 @@ export default class PageDetails extends React.Component {
 
   _versionsToRender () {
     const [fromId, toId] = (this.props.match.params.change || '').split('..');
-    let from = this.state.page.versions.find(v => v.uuid === fromId);
-    let to = this.state.page.versions.find(v => v.uuid === toId);
+    const firstVersion = this.state.page.versions[this.state.page.versions.length - 1];
+    let from = fromId === '^' ? firstVersion : this.state.page.versions.find(v => v.uuid === fromId);
+    let to = toId === '$' ? this.state.page.versions[0] : this.state.page.versions.find(v => v.uuid === toId);
 
     // Changes with no `to` are invalid, but those where `from` was never
     // specified are OK (it’ll be considered relative to `to`)


### PR DESCRIPTION
Resolves #180 

I went with the regex-like operators because I like symbols more than words.

I'm probably missing something about checking for html/url encoding but I'm not sure what to look out for. This seemed too straight-forward but is working.

Should I use a regex to match instead of [equality operators](https://github.com/edgi-govdata-archiving/web-monitoring-ui/blob/b72f4d5b80d41121848c6c6aca2b42215cb59c68/src/components/page-details.jsx#L180-L181)? 