### PR TITLE
HOTFIX: Fix `^..` route

### DIFF
--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -208,6 +208,11 @@ export default class PageDetails extends React.Component {
 
       if (fromId === '^') {
         from = versions[versions.length - 1];
+
+        // make `^..` go to first and next, instead of first and latest version
+        if (!toId) {
+          to = versions[versions.indexOf(from) - 1];
+        }
       }
       else {
         from = from || versions[versions.indexOf(to) + 1] || to;


### PR DESCRIPTION
I missed a case where `^..` goes to the first and latest version, which isn't consistent with how our shortcuts work.
This fix makes it go to first and its next version instead.