### PR TITLE
Only request diffs for types we *can* diff

### DIFF
--- a/src/components/change-view.jsx
+++ b/src/components/change-view.jsx
@@ -17,6 +17,7 @@ import {
 } from '../scripts/media-type';
 
 const collapsedViewStorage = 'WebMonitoring.ChangeView.collapsedView';
+const defaultDiffType = 'SIDE_BY_SIDE_RENDERED';
 
 /**
  * @typedef ChangeViewProps
@@ -52,7 +53,7 @@ export default class ChangeView extends React.Component {
     // TODO: unify this default state logic with componentWillReceiveProps
     const page = this.props.page;
     if (page.versions && page.versions.length > 1) {
-      this.state.diffType = 'SIDE_BY_SIDE_RENDERED';
+      this.state.diffType = defaultDiffType;
       const relevantTypes = relevantDiffTypes(this.props.from, this.props.to);
       if (!relevantTypes.find(type => type.value === this.state.diffType)) {
         this.state.diffType = relevantTypes[0].value;
@@ -82,7 +83,20 @@ export default class ChangeView extends React.Component {
   componentWillReceiveProps (nextProps) {
     const nextVersions = nextProps.page.versions;
     if (nextVersions && nextVersions.length > 1) {
+      // TODO: is this correct? seems like we should be checking nextProps.from/to
       this._getChange(nextVersions[1], nextVersions[0]);
+    }
+
+    if (nextProps.from && nextProps.to) {
+      // update the diff type
+      const relevantTypes = relevantDiffTypes(nextProps.from, nextProps.to);
+      if (!relevantTypes.find(type => type.value === this.state.diffType)) {
+        let diffType = relevantTypes[0].value;
+        if (relevantTypes.find(type => type.value === defaultDiffType)) {
+          diffType = defaultDiffType;
+        }
+        this.setState({diffType});
+      }
     }
   }
 

--- a/src/components/diff-view.jsx
+++ b/src/components/diff-view.jsx
@@ -35,7 +35,7 @@ export default class DiffView extends React.Component {
   componentWillMount () {
     const {props} = this;
     if (this._canFetch(props)) {
-      this._loadDiffData(props.page.uuid, props.a.uuid, props.b.uuid, props.diffType);
+      this._loadDiffData(props.page, props.a, props.b, props.diffType);
     }
   }
 
@@ -44,7 +44,7 @@ export default class DiffView extends React.Component {
    */
   componentWillReceiveProps (nextProps) {
     if (this._canFetch(nextProps) && !this._propsSpecifySameDiff(nextProps)) {
-      this._loadDiffData(nextProps.page.uuid, nextProps.a.uuid, nextProps.b.uuid, nextProps.diffType);
+      this._loadDiffData(nextProps.page, nextProps.a, nextProps.b, nextProps.diffType);
     }
   }
 
@@ -178,7 +178,7 @@ export default class DiffView extends React.Component {
     return (props.page.uuid && props.diffType && props.a && props.b && props.a.uuid && props.b.uuid);
   }
 
-  _loadDiffData (pageId, aId, bId, diffType) {
+  _loadDiffData (page, a, b, diffType) {
     // TODO - this seems to be some sort of caching mechanism, would be smart to have this for diffs
     // const fromList = this.props.pages && this.props.pages.find(
     //     (page: Page) => page.uuid === pageId);
@@ -186,8 +186,8 @@ export default class DiffView extends React.Component {
     this.setState({diffData: null});
     if (!diffTypes[diffType].diffService) {
       return Promise.all([
-        fetch(this.props.a.uri, {mode: 'cors'}),
-        fetch(this.props.b.uri, {mode: 'cors'})
+        fetch(a.uri, {mode: 'cors'}),
+        fetch(b.uri, {mode: 'cors'})
       ])
         .then(([rawA, rawB]) => {
           return {raw: true, rawA, rawB};
@@ -196,7 +196,13 @@ export default class DiffView extends React.Component {
         .then(data => this.setState({diffData: data}));
     }
 
-    this.context.api.getDiff(pageId, aId, bId, diffTypes[diffType].diffService, diffTypes[diffType].options)
+    this.context.api.getDiff(
+      page.uuid,
+      a.uuid,
+      b.uuid,
+      diffTypes[diffType].diffService,
+      diffTypes[diffType].options
+    )
       .catch(error => {
         return error;
       })

--- a/src/components/raw-version.jsx
+++ b/src/components/raw-version.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import SandboxedHtml from './sandboxed-html';
+
+/**
+ * @typedef {Object} RawVersionProps
+ * @property {Page} page The page this diff pertains to
+ * @property {Version} version
+ * @property {string} content
+ */
+
+/**
+ * Display the raw content of a version.
+ *
+ * @class RawVersion
+ * @extends {React.Component}
+ * @param {RawVersionProps} props
+ */
+export default class RawVersion extends React.Component {
+  render () {
+    if (this.props.content && /^[\s\n\r]*</.test(this.props.content)) {
+      return (
+        <div className="inline-render">
+          <SandboxedHtml html={this.props.content} baseUrl={this.props.page.url} />
+        </div>
+      );
+    }
+
+    return (
+      <div className="inline-render">
+        <iframe src={this.props.version.uri} />
+      </div>
+    );
+  }
+}

--- a/src/components/select-diff-type.jsx
+++ b/src/components/select-diff-type.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {diffTypes} from '../constants/diff-types';
 
 /**
  * A dropdown select box for types of diffs
@@ -10,6 +9,7 @@ import {diffTypes} from '../constants/diff-types';
  * @param {string} value Identifier for the selected diff type
  * @param {Function} onChange Callback when a new value is selected. Signature:
  *                            `string => void`
+ * @param {DiffType[]} types
  */
 export default class SelectDiffType extends React.Component {
   render () {
@@ -20,11 +20,12 @@ export default class SelectDiffType extends React.Component {
     return (
       <select value={this.props.value} onChange={handleChange}>
         <option value="">none</option>
-        {Object.keys(diffTypes).map(key => {
-          const diffType = diffTypes[key];
-          return <option key={diffType.value} value={diffType.value}>{diffType.description}</option>;
-        })}
+        {this.props.types.map(this._renderOption)}
       </select>
     );
+  }
+
+  _renderOption (diffType) {
+    return <option key={diffType.value} value={diffType.value}>{diffType.description}</option>;
   }
 }

--- a/src/components/side-by-side-raw-versions.jsx
+++ b/src/components/side-by-side-raw-versions.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import SandboxedHtml from './sandboxed-html';
+
+/**
+ * @typedef {Object} SideBySideRawVersionsProps
+ * @property {DiffData} diffData Object containing diff to render and its metadata
+ * @property {Page} page The page this diff pertains to
+ * @property {Version} a
+ * @property {Version} b
+ */
+
+/**
+ * Display two versions of a page, side-by-side.
+ *
+ * @class SideBySideRawVersions
+ * @extends {React.Component}
+ * @param {SideBySideRawVersionsProps} props
+ */
+export default class SideBySideRawVersions extends React.Component {
+  render () {
+    return (
+      <div className="side-by-side-render">
+        {renderVersion(this.props.page, this.props.a, this.props.diffData.rawA)}
+        {renderVersion(this.props.page, this.props.b, this.props.diffData.rawB)}
+      </div>
+    );
+  }
+}
+
+function renderVersion (page, version, content) {
+  if (content && /^[\s\n\r]*</.test(content)) {
+    return <SandboxedHtml html={contentcontent} baseUrl={page.url} />;
+  }
+
+  return <iframe src={version.uri} />;
+}

--- a/src/components/side-by-side-raw-versions.jsx
+++ b/src/components/side-by-side-raw-versions.jsx
@@ -29,7 +29,7 @@ export default class SideBySideRawVersions extends React.Component {
 
 function renderVersion (page, version, content) {
   if (content && /^[\s\n\r]*</.test(content)) {
-    return <SandboxedHtml html={contentcontent} baseUrl={page.url} />;
+    return <SandboxedHtml html={content} baseUrl={page.url} />;
   }
 
   return <iframe src={version.uri} />;

--- a/src/constants/diff-types.js
+++ b/src/constants/diff-types.js
@@ -1,4 +1,19 @@
+import {
+  mediaTypeForExtension,
+  parseMediaType,
+  unknownType
+} from '../scripts/media-type';
+
 export const diffTypes = {
+  RAW_FROM_CONTENT: {
+    description: '“From” Version',
+  },
+  RAW_TO_CONTENT: {
+    description: '“To” Version',
+  },
+  RAW_SIDE_BY_SIDE: {
+    description: 'Side-by-side Content',
+  },
   HIGHLIGHTED_TEXT: {
     description: 'Highlighted Text',
     diffService: 'html_text_dmp',
@@ -32,4 +47,48 @@ export const diffTypes = {
 
 for (let key in diffTypes) {
   diffTypes[key].value = key;
+}
+
+const diffTypesByMediaType = {
+  'text/html': [
+    diffTypes.HIGHLIGHTED_TEXT,
+    diffTypes.HIGHLIGHTED_SOURCE,
+    diffTypes.HIGHLIGHTED_RENDERED,
+    diffTypes.SIDE_BY_SIDE_RENDERED,
+    diffTypes.OUTGOING_LINKS,
+    diffTypes.CHANGES_ONLY_TEXT,
+    diffTypes.CHANGES_ONLY_SOURCE,
+  ],
+
+  'text/*': [
+    diffTypes.HIGHLIGHTED_SOURCE,
+    diffTypes.CHANGES_ONLY_SOURCE,
+  ],
+
+  '*/*': [
+    diffTypes.RAW_SIDE_BY_SIDE,
+    diffTypes.RAW_FROM_CONTENT,
+    diffTypes.RAW_TO_CONTENT,
+  ],
+};
+
+/**
+ * Get appropriate diff types for a given kind of content.
+ * @param {string|MediaType} mediaType The type of content to get. Can be a
+ *   MediaType object, a content type/media type string, or a file extension.
+ * @returns {Array<DiffType>}
+ */
+export function diffTypesFor (mediaType) {
+  let type = null;
+  if (typeof mediaType === 'string' && mediaType.startsWith('.')) {
+    type = mediaTypeForExtension(mediaType) || unknownType;
+  }
+  else {
+    type = parseMediaType(mediaType);
+  }
+
+  return diffTypesByMediaType[type.mediaType]
+    || diffTypesByMediaType[type.genericType]
+    || diffTypesByMediaType[unknownType.mediaType]
+    || [];
 }

--- a/src/scripts/__tests__/media-type.test.js
+++ b/src/scripts/__tests__/media-type.test.js
@@ -1,0 +1,64 @@
+/* eslint-env jest */
+
+import MediaType, {parseMediaType} from '../media-type';
+
+describe('MediaType module', () => {
+  test('MediaType objects have a mediaType and genericType', () => {
+    const type = MediaType('type', 'subtype');
+    expect(type.type).toBe('type');
+    expect(type.subtype).toBe('subtype');
+    expect(type.mediaType).toBe('type/subtype');
+    expect(type.genericType).toBe('type/*');
+  });
+
+  test('MediaType objects with no subtype have a "*" subtype', () => {
+    const type = MediaType('type');
+    expect(type.type).toBe('type');
+    expect(type.subtype).toBe('*');
+    expect(type.mediaType).toBe('type/*');
+    expect(type.genericType).toBe('type/*');
+  });
+
+  test('MediaType.equals should return true for two identical type instances', () => {
+    const type = MediaType('type', 'subtype');
+    const otherType = MediaType('type', 'subtype');
+    expect(type.equals(otherType)).toBe(true);
+  });
+
+  test('MediaType.equals should return false for two non-identical type instances', () => {
+    const type = MediaType('type', 'subtype');
+    const otherType = MediaType('type', 'otherSubtype');
+    expect(type.equals(otherType)).toBe(false);
+  });
+
+  test('parseMediaType should return a MediaType instance that matches a media type string', () => {
+    const type = parseMediaType('type/subtype');
+    expect(type.type).toBe('type');
+    expect(type.subtype).toBe('subtype');
+    expect(type.mediaType).toBe('type/subtype');
+    expect(type.genericType).toBe('type/*');
+  });
+
+  test('parseMediaType should return the MediaType instance it receives if one is passed instead of a string', () => {
+    const type = MediaType('type', 'subtype');
+    const parsedType = parseMediaType(type);
+    expect(parsedType).toBe(type);
+  });
+
+  test('parseMediaType should throw an error if it does not receive a string or MediaType', () => {
+    expect(() => {
+      parseMediaType(5);
+    }).toThrow(TypeError);
+  });
+
+  test('parseMediaType should return a known canonical type if one matches the parsed type', () => {
+    const type = parseMediaType('application/xhtml+xml');
+    expect(type.mediaType).toBe('text/html');
+    expect(type.exactType.mediaType).toBe('application/xhtml+xml');
+  });
+
+  test('parseMediaType should not return a canonical type if `canonicalize` is false', () => {
+    const type = parseMediaType('application/xhtml+xml', false);
+    expect(type.mediaType).toBe('application/xhtml+xml');
+  });
+});

--- a/src/scripts/media-type.js
+++ b/src/scripts/media-type.js
@@ -72,7 +72,7 @@ export const mediaTypeForExtension = {
   '.xls':  MediaType('application', 'vnd.ms-excel'),
   '.xlsx': MediaType('application', 'vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
   '.png':  MediaType('image', 'png'),
-  '.docx': MediaType('application', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'),
+  '.docx': MediaType('application', 'vnd.openxmlformats-officedocument.wordprocessingml.document'),
   '.jpeg': MediaType('image', 'jpeg'),
   '.mp3':  MediaType('audio', 'mpeg'),
   '.ai':   MediaType('application', 'postscript'),

--- a/src/scripts/media-type.js
+++ b/src/scripts/media-type.js
@@ -1,0 +1,119 @@
+/**
+ * Tools for dealing with media types.
+ */
+
+/**
+ * @typedef MediaType Represents a media type.
+ * @property {string} mediaType The full media type string, e.g. 'text/plain'
+ * @property {string} type The primary type, e.g. 'text' in 'text/plain'
+ * @property {string} subType The sub type, e.g. 'plain' in 'text/plain'
+ * @property {string} genericType The generic type, e.g. 'text/*'
+ * @property {(MediaType) => boolean} equals Compare this MediaType with another
+ */
+
+/**
+ * The "unknown" media type.
+ * @type {MediaType}
+ */
+export const unknownType = {
+  genericType: '*/*',
+  mediaType: '*/*',
+  type: '*',
+  subType: '*',
+  equals (otherType) {
+    return !!otherType && this.mediaType === otherType.mediaType;
+  }
+};
+
+/**
+ * The canonical HTML media type.
+ * @type {MediaType}
+ */
+export const htmlType = MediaType('text', 'html');
+
+/**
+ * Create an object representing a media type.
+ * @param {string} [type]
+ * @param {string} [subtype]
+ * @returns {MediaType}
+ */
+export default function MediaType (type, subtype) {
+  type = type || '*';
+  subtype = subtype || '*';
+
+  return Object.assign(Object.create(unknownType), {
+    genericType: `${type}/*`,
+    mediaType: `${type}/${subtype || '*'}`,
+    type,
+    subtype,
+  });
+}
+
+// TODO: remove this when we have content types for everything in the DB
+export const mediaTypeForExtension = {
+  '.html': htmlType,
+  '.pdf':  MediaType('application', 'pdf'),
+  '.wsdl': MediaType('application', 'wsdl+xml'),
+  '.xml':  MediaType('application', 'xml'),
+  '.ksh':  MediaType('text', '*'),
+  '.ics':  MediaType('text', 'calendar'),
+  '.txt':  MediaType('text', 'plain'),
+  '.rss':  MediaType('application', 'rss+xml'),
+  '.jpg':  MediaType('image', 'jpeg'),
+  '.obj':  MediaType('application', 'x-tgif'),
+  '.doc':  MediaType('application', 'msword'),
+  '.zip':  MediaType('application', 'zip'),
+  '.atom': MediaType('application', 'atom+xml'),
+  '.xlb':  MediaType('application', 'excel'),
+  '.pwz':  MediaType('application', 'powerpoint'),
+  '.gif':  MediaType('image', 'gif'),
+  '.rtf':  MediaType('application', 'rtf'),
+  '.csv':  MediaType('text', 'csv'),
+  '.xls':  MediaType('application', 'vnd.ms-excel'),
+  '.xlsx': MediaType('application', 'vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
+  '.png':  MediaType('image', 'png'),
+  '.docx': MediaType('application', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'),
+  '.jpeg': MediaType('image', 'jpeg'),
+  '.mp3':  MediaType('audio', 'mpeg'),
+  '.ai':   MediaType('application', 'postscript'),
+};
+
+// Maps various media types representing the same thing to a canonical type.
+const canonicalTypes = {
+  'application/xhtml': htmlType,
+  'application/xhtml+xml': htmlType,
+  'application/xml+html': htmlType,
+  'text/webviewhtml': htmlType,
+  'text/x-server-parsed-html': htmlType,
+  'text/xhtml': htmlType,
+};
+
+/**
+ * Convert a media type string to a MediaType object.
+ * @param {string|MediaType} mediaType
+ * @param {boolean} [canonicalize=true]
+ * @returns {MediaType}
+ */
+export function parseMediaType (mediaType, canonicalize = true) {
+  if (mediaType == null) {
+    mediaType = '*/*';
+  }
+  else if (mediaType.mediaType) {
+    return mediaType;
+  }
+  else if (!(typeof mediaType === 'string')) {
+    throw new TypeError(`The 'mediaType' argument must be a string, not \`${mediaType}\``);
+  }
+
+  const parts = mediaType.match(/^([^/;]+)(?:\/([^;]+))?/) || [];
+  let parsed = MediaType(parts[1], parts[2]);
+
+  if (canonicalize) {
+    let canonicalType = canonicalTypes[parsed.mediaType];
+    if (canonicalType) {
+      parsed = Object.create(canonicalType, {exactType: {value: parsed}});
+    }
+  }
+
+  return parsed;
+}


### PR DESCRIPTION
This got much more complex than anticipated! There are a few major bits here:

- We now have a `MediaType` type for modeling and comparing different media types. It includes a concept of canonical types, so `parseMediaType('text/html').equals(parseMediaType('application/xhtml')) === true`. If we can reliably clean this up in the DB, we can get rid of that, but it's useful for now.
  Similarly, we can also get media types for file extensions (it only supports a minimal list of extensions we know we have in the DB). Once the DB has content types for all versions, we can get rid of that, too.

- The `diffTypes` module now has a `diffTypesFor(mediaType)` method, allowing us to get the diffs that are appropriate to present for a given type of content. We've also added three "raw" diff types which indicate we should simply show the content in an `<iframe>` because we don't know how to diff it (or if the two versions in question have differing content types, which often happens when a PDF or image responded with an HTML error page [like a 404] for a given version).

- The `SelectDiffType` form control now takes a list of diff types (from the above `diffTypesFor()`) to show.

- There's a little extra complexity in retrieving an actual diff where we check to see if the diff type has an actual diff service associated with it ("raw" types don't, because they represent viewing the actual content, not a diff). We request the actual raw content there because we need to sniff it for HTML (when we present HTML, we need to set a `<base>` tag so associated images, styles, and scripts work). This part is definitely a little janky, but I don't see a clear improvement without a lot more other changes. It slightly exacerbates the existing race condition issue. The sniffing HTML situation should/could probably be fixed alongside https://github.com/edgi-govdata-archiving/web-monitoring/issues/92, where we basically need some kind of proxy or pre-cleaned-up version to render.

- Finally, this makes a slight tweak to the “no changes” message; it shows a message indicating two versions are exactly the same if their hashes are identical, but shows the old message (with slightly more detail) if the hashes are different but `change_count` is 0.

Fixes #179.

![screenshot-html-vs-pdf](https://user-images.githubusercontent.com/74178/35793985-ad80972a-0a08-11e8-90b1-1d7f41f23a6d.png)
A page where two versions have differing content types (HTML vs. PDF)


![screenshot-pdf-only](https://user-images.githubusercontent.com/74178/35793994-b6e5b1ce-0a08-11e8-8da8-aab6269bf0ef.png)
Viewing only the newer version of a page and getting raw content because it is a PDF


![screenshot-identical-versions](https://user-images.githubusercontent.com/74178/35793990-b313cfcc-0a08-11e8-982a-5f8914c1d870.png)
Message about identical version content
