### PR TITLE
Automatically publish docker images with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:6.11.1
+      - image: circleci/node:8.10.0
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,3 +20,40 @@ jobs:
       - run:
           name: Test
           command: yarn test
+
+  publish_docker:
+    machine: true
+    steps:
+      - checkout
+      - run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run: |
+          docker build -t envirodgi/ui:$CIRCLE_SHA1 .
+          docker build -t envirodgi/ui:latest .
+      - run: |
+          docker push envirodgi/ui:$CIRCLE_SHA1
+          docker push envirodgi/ui:latest
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: master
+
+  build-and-publish:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only:
+                - master
+      - approve_docker_publish:
+          type: approval
+          requires:
+            - build
+      - publish_docker:
+          requires:
+            - approve_docker_publish


### PR DESCRIPTION
Auto-publishes the `envirodgi/ui:<latest and commit hash>` image whenever the master branch updates. This keeps publishing nice and easy and makes sure it’s a clean build every time.

Fixes #213. This is basically the same as https://github.com/edgi-govdata-archiving/web-monitoring-db/pull/246