### PR TITLE
Unblock #264-db with Nov. 1, 2016 cutoff

### DIFF
--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -227,20 +227,20 @@ export default class PageDetails extends React.Component {
     const fromList = this.props.pages && this.props.pages.find(
       (page) => page.uuid === pageId && !!page.versions);
     
-    Promise.resolve(fromList || this.context.api.getPage(pageId))
-      .then((page) => {
-        this._loadVersions(page, '2016-11-01', '');
-      });
-  }
-
-  _loadVersions(page, fromDate, toDate) {
     /** HACK: To deal with the huge number of versions coming from Internet Archive,
      * we're returning only versions captured after November 1, 2016 until we figure out a 
      * better solution. Probably an improved iteration of timeline idea:
      * https://github.com/edgi-govdata-archiving/web-monitoring-ui/pull/98
      * Issue outlined here: https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
      */
-    const capture_time = {'capture_time': `${fromDate}..${toDate}`};
+    Promise.resolve(fromList || this.context.api.getPage(pageId))
+      .then((page) => {
+        this._loadVersions(page, '2016-11-01', '');
+      });
+  }
+
+  _loadVersions(page, dateFrom, dateTo) {
+    const capture_time = {'capture_time': `${dateFrom}..${dateTo}`};
     Promise.resolve(this.context.api.getVersions(page.uuid, capture_time))
       .then(versions => {
         page.versions = versions;

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -233,9 +233,10 @@ export default class PageDetails extends React.Component {
      * https://github.com/edgi-govdata-archiving/web-monitoring-ui/pull/98
      * Issue outlined here: https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
      */
+    const cutoffDate = '2016-11-01';
     Promise.resolve(fromList || this.context.api.getPage(pageId))
       .then((page) => {
-        this._loadVersions(page, '2016-11-01', '');
+        this._loadVersions(page, cutoffDate, '');
       });
   }
 

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -233,7 +233,7 @@ export default class PageDetails extends React.Component {
      * https://github.com/edgi-govdata-archiving/web-monitoring-ui/pull/98
      * Issue outlined here: https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
      */
-    const cutoffDate = '2000-11-01';
+    const cutoffDate = '2016-11-01';
     Promise.resolve(fromList || this.context.api.getPage(pageId))
       .then(page => {
         this._loadVersions(page, cutoffDate, '')

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -227,19 +227,24 @@ export default class PageDetails extends React.Component {
     const fromList = this.props.pages && this.props.pages.find(
       (page) => page.uuid === pageId && !!page.versions);
     
-    /** HACK: To deal with the huge number of versions coming from Internet Archive,
-     * we're returning only versions captured after November 1, 2016 until we figure out a 
-     * better solution. Probably an improved iteration of timeline idea: https://github.com/edgi-govdata-archiving/web-monitoring-ui/pull/98
-     * Issue outlined here: https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
-     */
-    const capture_time = {'capture_time': '2016-11-01..'};
     Promise.resolve(fromList || this.context.api.getPage(pageId))
       .then((page) => {
-        this.context.api.getVersions(page.uuid, capture_time)
-          .then(versions => {
-            page.versions = versions;
-            this.setState({page});
-          });
+        this._loadVersions(page, '2016-11-01', '');
+      });
+  }
+
+  _loadVersions(page, fromDate, toDate) {
+    /** HACK: To deal with the huge number of versions coming from Internet Archive,
+     * we're returning only versions captured after November 1, 2016 until we figure out a 
+     * better solution. Probably an improved iteration of timeline idea:
+     * https://github.com/edgi-govdata-archiving/web-monitoring-ui/pull/98
+     * Issue outlined here: https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
+     */
+    const capture_time = {'capture_time': `${fromDate}..${toDate}`};
+    Promise.resolve(this.context.api.getVersions(page.uuid, capture_time))
+      .then(versions => {
+        page.versions = versions;
+        this.setState({page});
       });
   }
 

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -247,7 +247,7 @@ export default class PageDetails extends React.Component {
 
   _loadVersions(page, dateFrom, dateTo) {
     const capture_time = {'capture_time': `${dateFrom}..${dateTo}`};
-    return this.context.api.getAllVersions(page.uuid, capture_time);
+    return this.context.api.getVersions(page.uuid, capture_time, Infinity);
   }
 
   _getChangeUrl (from, to, page) {

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -5,6 +5,8 @@ import WebMonitoringDb from '../services/web-monitoring-db';
 import ChangeView from './change-view';
 import Loading from './loading';
 
+const cutoffDate = '2016-11-01';
+
 /**
  * @typedef {Object} PageDetailsProps
  * @property {Page[]} pages
@@ -233,7 +235,6 @@ export default class PageDetails extends React.Component {
      * https://github.com/edgi-govdata-archiving/web-monitoring-ui/pull/98
      * Issue outlined here: https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
      */
-    const cutoffDate = '2016-11-01';
     Promise.resolve(fromList || this.context.api.getPage(pageId))
       .then(page => {
         this._loadVersions(page, cutoffDate, '')

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -226,10 +226,20 @@ export default class PageDetails extends React.Component {
     // TODO: handle the missing `.versions` collection problem better
     const fromList = this.props.pages && this.props.pages.find(
       (page) => page.uuid === pageId && !!page.versions);
-
+    
+    /** HACK: To deal with the huge number of versions coming from Internet Archive,
+     * we're returning only versions captured after November 1, 2016 until we figure out a 
+     * better solution. Probably an improved iteration of timeline idea: https://github.com/edgi-govdata-archiving/web-monitoring-ui/pull/98
+     * Issue outlined here: https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
+     */
+    const capture_time = {'capture_time': '2016-11-01..'};
     Promise.resolve(fromList || this.context.api.getPage(pageId))
       .then((page) => {
-        this.setState({page});
+        this.context.api.getVersions(page.uuid, capture_time)
+          .then(versions => {
+            page.versions = versions;
+            this.setState({page});
+          });
       });
   }
 

--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -233,20 +233,20 @@ export default class PageDetails extends React.Component {
      * https://github.com/edgi-govdata-archiving/web-monitoring-ui/pull/98
      * Issue outlined here: https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264
      */
-    const cutoffDate = '2016-11-01';
+    const cutoffDate = '2000-11-01';
     Promise.resolve(fromList || this.context.api.getPage(pageId))
-      .then((page) => {
-        this._loadVersions(page, cutoffDate, '');
+      .then(page => {
+        this._loadVersions(page, cutoffDate, '')
+          .then(versions => {
+            page.versions = versions;
+            this.setState({page});
+          });
       });
   }
 
   _loadVersions(page, dateFrom, dateTo) {
     const capture_time = {'capture_time': `${dateFrom}..${dateTo}`};
-    Promise.resolve(this.context.api.getVersions(page.uuid, capture_time))
-      .then(versions => {
-        page.versions = versions;
-        this.setState({page});
-      });
+    return this.context.api.getAllVersions(page.uuid, capture_time);
   }
 
   _getChangeUrl (from, to, page) {

--- a/src/services/web-monitoring-db.js
+++ b/src/services/web-monitoring-db.js
@@ -182,6 +182,7 @@ export default class WebMonitoringDb {
   getPages (query) {
     return this._request(this._createUrl('pages', query))
       .then(response => response.json())
+      .then(throwIfError(`Could not load pages`))
       .then(data => data.data.map(parsePage));
   }
 
@@ -193,6 +194,7 @@ export default class WebMonitoringDb {
   getPage (pageId) {
     return this._request(this._createUrl(`pages/${pageId}`))
       .then(response => response.json())
+      .then(throwIfError(`Could not load page: ${pageId}`))
       .then(data => parsePage(data.data));
   }
 
@@ -228,6 +230,7 @@ export default class WebMonitoringDb {
   getVersion (versionId) {
     return this._request(this._createUrl(`versions/${versionId}`))
       .then(response => response.json())
+      .then(throwIfError(`Could not load version: ${versionId}`))
       .then(data => parseVersion(data.data));
   }
 
@@ -243,6 +246,7 @@ export default class WebMonitoringDb {
     toVersion = toVersion || '';
     return this._request(this._createUrl(`pages/${pageId}/changes/${fromVersion}..${toVersion}`))
       .then(response => response.json())
+      .then(throwIfError(`Could not load change from: pages/${pageId}/changes/${fromVersion}..${toVersion}`))
       .then(data => parseChange(data.data));
   }
 

--- a/src/services/web-monitoring-db.js
+++ b/src/services/web-monitoring-db.js
@@ -202,9 +202,22 @@ export default class WebMonitoringDb {
      * @returns {Promise<Version[]>}
      */
   getVersions (pageId, query) {
-    return this._request(this._createUrl(`pages/${pageId}/versions`, query))
-      .then(response => response.json())
-      .then(data => data.data.map(parseVersion));
+    return this.joinPaginatedVersions(this._createUrl(`pages/${pageId}/versions`, query));
+  }
+
+  joinPaginatedVersions (url, data) {
+    if (!url) {
+      return data;
+    }
+    else {
+      let joinedData = data || [];
+      return this._request(url)
+        .then(response => response.json())
+        .then(data => {
+          joinedData.push(...data.data.map(parseVersion));
+          return this.joinPaginatedVersions(data.links.next, joinedData);
+        });
+    }
   }
 
   /**

--- a/src/services/web-monitoring-db.js
+++ b/src/services/web-monitoring-db.js
@@ -201,8 +201,8 @@ export default class WebMonitoringDb {
      * @param {string} pageId
      * @returns {Promise<Version[]>}
      */
-  getVersions (pageId) {
-    return this._request(this._createUrl(`pages/${pageId}/versions`))
+  getVersions (pageId, query) {
+    return this._request(this._createUrl(`pages/${pageId}/versions`, query))
       .then(response => response.json())
       .then(data => data.data.map(parseVersion));
   }

--- a/src/services/web-monitoring-db.js
+++ b/src/services/web-monitoring-db.js
@@ -177,13 +177,12 @@ export default class WebMonitoringDb {
   /**
      * Get pages.
      * @param {Object} [query]
+     * @param {number} limitChunks
      * @returns {Promise<Page[]>}
      */
-  getPages (query) {
-    return this._request(this._createUrl('pages', query))
-      .then(response => response.json())
-      .then(throwIfError('Could not load pages'))
-      .then(data => data.data.map(parsePage));
+  getPages (query, limitChunks = 1) {
+    const url = this._createUrl('pages', query);
+    return this._getListChunks(url, parsePage, limitChunks);
   }
 
   /**
@@ -199,33 +198,15 @@ export default class WebMonitoringDb {
   }
 
   /**
-     * Recursively get a list of all versions for a given page.
-     * @param {string} pageId
-     * @param {string} query
-     * @returns {Promise<Version[]>}
-     */
-
-  getAllVersions (pageId, query) {
-    const api = this;
-    const url = api._createUrl(`pages/${pageId}/versions`, query);
-
-    return new Promise((resolve, reject) => {
-      let allVersions = [];
-      let getVersionsChunk = url => {
-        api._request(url)
-          .then(response => response.json())
-          .then(throwIfError(`Could not load versions from: ${url}`))
-          .then(data => {
-            allVersions.push(...data.data.map(parseVersion));
-            if (!data.links.next) {
-              resolve(allVersions);
-            } else {
-              getVersionsChunk(data.links.next);
-            }
-          });
-      };
-      getVersionsChunk(url);
-    });
+   * Get list of versions for a given page.
+   * @param {string} pageId
+   * @param {string} query
+   * @param {number} limitChunks
+   * @returns {Promise<Version[]>}
+   */
+  getVersions (pageId, query, limitChunks = 1) {
+    const url = this._createUrl(`pages/${pageId}/versions`, query);
+    return this._getListChunks(url, parseVersion, limitChunks);
   }
 
   /**
@@ -399,6 +380,25 @@ export default class WebMonitoringDb {
 
   _authHeader () {
     return `Bearer ${this.authToken}`;
+  }
+
+  _getListChunk (url, parser) {
+    return this._request(url)
+      .then(response => response.json())
+      .then(throwIfError(`Could not load: ${url}`))
+      .then(chunk => {
+        chunk.data = chunk.data.map(parser);
+        return chunk;
+      });
+  }
+
+  _getListChunks (url, parser, limit = Infinity, result = []) {
+    if (!url || !limit) return Promise.resolve(result);
+    return this._getListChunk(url, parser)
+      .then(chunk => {
+        result.push(...chunk.data);
+        return this._getListChunks(chunk.links.next, parser, limit - 1, result);
+      });
   }
 }
 


### PR DESCRIPTION
Fixes #215 

This is step 1 to unblocking [#264-db](https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/264). We can probably merge now, to stop blocking if absolutely necessary. If not, we can wait while I finish off #217 which is to make the cutoff adjustable through settings. That PR would be built on top of this.

We're now grabbing versions by paginating through the `page/{page_id}/versions` endpoint. We're using the agreed upon Nov. 1, 2016 cutoff, which is just a constant passed to the new `_loadversions` method.