### PR TITLE
Add linting precommit step with husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "extract-loader": "^1.0.1",
     "fetch-mock": "^5.12.1",
     "file-loader": "^1.1.6",
+    "husky": "^0.14.3",
     "jest": "^22.1.4",
     "postcss-loader": "^2.0.10",
     "prop-types": "^15.5.10",
@@ -42,6 +43,7 @@
     "build": "webpack",
     "build-production": "NODE_ENV=production webpack",
     "lint": "eslint --ignore-path .gitignore './**/*.{js,jsx}'",
+    "precommit": "yarn run lint",
     "start": "node server/app.js",
     "test": "jest --colors",
     "test-watch": "jest --watch"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2763,6 +2763,14 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -3971,6 +3979,10 @@ normalize-package-data@^2.3.2:
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
+
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"
@@ -5451,6 +5463,10 @@ strip-bom@^2.0.0:
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Fixes #178 

Does what it says on the tin with [husky](https://github.com/typicode/husky).

Realized that linting during build isn't as useful, because it's easy to miss the warnings if you're not looking at the terminal after making a change and the app can still run fine with a previous build. 


