### PR TITLE
HOTFIX: InlineRenderedDiff has many diff types

### DIFF
--- a/src/components/inline-rendered-diff.jsx
+++ b/src/components/inline-rendered-diff.jsx
@@ -18,7 +18,7 @@ import SandboxedHtml from './sandboxed-html';
  */
 export default class InlineRenderedDiff extends React.Component {
   render () {
-    const diff = this.props.diffData.combined;
+    const diff = this.props.diffData.combined || this.props.diffData.diff;
     const transformDocument = this.props.removeFormatting && removeStyleAndScript;
 
     return (


### PR DESCRIPTION
In the remove formatting feature, we overzealously removed handling of multiple kinds of diffs. In particular we didn't just remove old-style formatting, but we removed handling of multiple *types* of diffs, and made `InlineRenderedDiff` only able to handle HTML token diffs, which was not correct.