### PR TITLE
Add `scratch*` files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ archives/.idea/
 .vscode/
 .DS_Store
 dist
+scratch*


### PR DESCRIPTION
I keep scratch files (usually named `scratch.md` or `scratch.js` etc.) around in the root of my working directory as a place to store bits of useful code, algorithms I'm playing with, or example snippets of scripts I've run against the source (e.g. for transformations and updates) and the deployed code (ways to use the API from my CLI). We ignore these in some other repos (https://github.com/edgi-govdata-archiving/web-monitoring-db/blob/f3c235b792bc52944be58a0a5bfd84eb41386e80/.gitignore#L12) and it'd be nice to add this here.

I've been ignoring these locally for a long time, but since we added Husky, dealing with them has become a major pain. This fixes that.