### PR TITLE
288-hotfix: Always render search bar

### DIFF
--- a/src/components/page-list.jsx
+++ b/src/components/page-list.jsx
@@ -28,14 +28,12 @@ export default class PageList extends React.Component {
       return <Loading />;
     }
 
-    if (this.props.pages instanceof Error) {
-      return this.renderError(`Could not load pages: ${this.props.pages.message}`);
-    }
-
-    const noPages = this.props.pages.length === 0;
     let results;
 
-    if (noPages) {
+    if (this.props.pages instanceof Error) {
+      results = this.renderError(`Could not load pages: ${this.props.pages.message}`);
+    }
+    else if (this.props.pages.length === 0) {
       results = this.renderError('There were no page results.', 'warning');
     }
     else {

--- a/src/components/page-list.jsx
+++ b/src/components/page-list.jsx
@@ -31,8 +31,15 @@ export default class PageList extends React.Component {
     if (this.props.pages instanceof Error) {
       return this.renderError(`Could not load pages: ${this.props.pages.message}`);
     }
-    else if (this.props.pages.length === 0) {
-      return this.renderError('You don’t have any assigned pages.', 'warning');
+
+    const noPages = this.props.pages.length === 0;
+    let results;
+
+    if (noPages) {
+      results = this.renderError('There were no page results.', 'warning');
+    }
+    else {
+      results = this.renderPages();
     }
 
     return (
@@ -44,17 +51,23 @@ export default class PageList extends React.Component {
             onChange={this._didSearch}
           />
         </div>
-        <div className="row">
-          <div className="col-md-12">
-            <table className="page-list table">
-              <thead>
-                {this.renderHeader()}
-              </thead>
-              <tbody>
-                {this.props.pages.map(page => this.renderRow(page))}
-              </tbody>
-            </table>
-          </div>
+        {results}
+      </div>
+    );
+  }
+
+  renderPages () {
+    return (
+      <div className="row">
+        <div className="col-md-12">
+          <table className="page-list table">
+            <thead>
+              {this.renderHeader()}
+            </thead>
+            <tbody>
+              {this.props.pages.map(page => this.renderRow(page))}
+            </tbody>
+          </table>
         </div>
       </div>
     );


### PR DESCRIPTION
Fixes #288 

Not the most optimal thing because we're still not addressing this [TODO](https://github.com/edgi-govdata-archiving/web-monitoring-ui/blob/78beb63a679f7cf436fee97d2a7d73d4ac3fc875/src/components/web-monitoring-ui.jsx#L111), but this makes sure the search bar is always rendered and allows users to fix their search if no results are found. 

I also edited the message. The old message didn't make sense because we haven't addressed the TODO and aren't using assigned pages yet.