### PR TITLE
Show source in version selector

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,8 @@
   "rules": {
     "indent": [
       "error",
-      2
+      2,
+      {"SwitchCase": 1}
     ],
     "linebreak-style": [
       "error",

--- a/src/components/diff-view.jsx
+++ b/src/components/diff-view.jsx
@@ -127,52 +127,52 @@ export default class DiffView extends React.Component {
     // in the future (e.g. inline vs. side-by-side text), we need a better
     // way to ensure we use the correct rendering and avoid race conditions
     switch (this.props.diffType) {
-    case diffTypes.RAW_SIDE_BY_SIDE.value:
-      return (
-        <SideBySideRawVersions {...commonProps} />
-      );
-    case diffTypes.RAW_FROM_CONTENT.value:
-      return (
-        <RawVersion page={this.props.page} version={this.props.a} content={this.state.diffData.rawA} />
-      );
-    case diffTypes.RAW_TO_CONTENT.value:
-      return (
-        <RawVersion page={this.props.page} version={this.props.b} content={this.state.diffData.rawB} />
-      );
-    case diffTypes.HIGHLIGHTED_RENDERED.value:
-      return (
-        <InlineRenderedDiff {...commonProps}
-          removeFormatting={this.props.diffSettings.removeFormatting}
-          useWaybackResources={this.props.diffSettings.useWaybackResources} />
-      );
-    case diffTypes.SIDE_BY_SIDE_RENDERED.value:
-      return (
-        <SideBySideRenderedDiff {...commonProps}
-          removeFormatting={this.props.diffSettings.removeFormatting}
-          useWaybackResources={this.props.diffSettings.useWaybackResources} />
-      );
-    case diffTypes.OUTGOING_LINKS.value:
-      return (
-        <InlineRenderedDiff {...commonProps} />
-      );
-    case diffTypes.HIGHLIGHTED_TEXT.value:
-      return (
-        <HighlightedTextDiff diffData={this.state.diffData} className='diff-text-inline' />
-      );
-    case diffTypes.HIGHLIGHTED_SOURCE.value:
-      return (
-        <HighlightedTextDiff diffData={this.state.diffData} className='diff-source-inline' />
-      );
-    case diffTypes.CHANGES_ONLY_TEXT.value:
-      return (
-        <ChangesOnlyDiff diffData={this.state.diffData} className='diff-text-inline' />
-      );
-    case diffTypes.CHANGES_ONLY_SOURCE.value:
-      return (
-        <ChangesOnlyDiff diffData={this.state.diffData} className='diff-source-inline' />
-      );
-    default:
-      return null;
+      case diffTypes.RAW_SIDE_BY_SIDE.value:
+        return (
+          <SideBySideRawVersions {...commonProps} />
+        );
+      case diffTypes.RAW_FROM_CONTENT.value:
+        return (
+          <RawVersion page={this.props.page} version={this.props.a} content={this.state.diffData.rawA} />
+        );
+      case diffTypes.RAW_TO_CONTENT.value:
+        return (
+          <RawVersion page={this.props.page} version={this.props.b} content={this.state.diffData.rawB} />
+        );
+      case diffTypes.HIGHLIGHTED_RENDERED.value:
+        return (
+          <InlineRenderedDiff {...commonProps}
+            removeFormatting={this.props.diffSettings.removeFormatting}
+            useWaybackResources={this.props.diffSettings.useWaybackResources} />
+        );
+      case diffTypes.SIDE_BY_SIDE_RENDERED.value:
+        return (
+          <SideBySideRenderedDiff {...commonProps}
+            removeFormatting={this.props.diffSettings.removeFormatting}
+            useWaybackResources={this.props.diffSettings.useWaybackResources} />
+        );
+      case diffTypes.OUTGOING_LINKS.value:
+        return (
+          <InlineRenderedDiff {...commonProps} />
+        );
+      case diffTypes.HIGHLIGHTED_TEXT.value:
+        return (
+          <HighlightedTextDiff diffData={this.state.diffData} className='diff-text-inline' />
+        );
+      case diffTypes.HIGHLIGHTED_SOURCE.value:
+        return (
+          <HighlightedTextDiff diffData={this.state.diffData} className='diff-source-inline' />
+        );
+      case diffTypes.CHANGES_ONLY_TEXT.value:
+        return (
+          <ChangesOnlyDiff diffData={this.state.diffData} className='diff-text-inline' />
+        );
+      case diffTypes.CHANGES_ONLY_SOURCE.value:
+        return (
+          <ChangesOnlyDiff diffData={this.state.diffData} className='diff-source-inline' />
+        );
+      default:
+        return null;
     }
   }
 

--- a/src/components/select-version.jsx
+++ b/src/components/select-version.jsx
@@ -39,8 +39,8 @@ export default class SelectVersion extends React.PureComponent {
 
 function sourceLabel (version) {
   switch (version.source_type) {
-    case 'versionista':      return ' (V)';
-    case 'internet_archive': return ' (IA)';
+    case 'versionista':      return ' (Versionista)';
+    case 'internet_archive': return ' (Wayback)';
     default:                 return '';
   }
 }

--- a/src/components/select-version.jsx
+++ b/src/components/select-version.jsx
@@ -23,7 +23,7 @@ export default class SelectVersion extends React.PureComponent {
     const options = versions.map(version => {
       return (
         <option key={version.uuid} value={version.uuid}>
-          {dateFormatter.format(version.capture_time)}
+          {dateFormatter.format(version.capture_time)}{sourceLabel(version)}
         </option>
       );
     });
@@ -34,5 +34,13 @@ export default class SelectVersion extends React.PureComponent {
         {options}
       </select>
     );
+  }
+}
+
+function sourceLabel (version) {
+  switch (version.source_type) {
+    case 'versionista':      return ' (V)';
+    case 'internet_archive': return ' (IA)';
+    default:                 return '';
   }
 }

--- a/src/components/versionista-info.jsx
+++ b/src/components/versionista-info.jsx
@@ -63,14 +63,14 @@ export default class VersionistaInfo extends React.Component {
       'Versionista stores only 50 versions: The latest 49 and the first captured version.');
 
     switch (datesWithoutDiff.length) {
-    case 0:
-      return null;
-    case 1:
-      return <span>Version from <strong>{datesWithoutDiff[0]}</strong> is no longer in Versionista. {tooltip}</span>;
-    case 2:
-      return <span>Both versions are no longer in Versionista. {tooltip}</span>;
-    default:
-      return <span>Something unexpected happened. Please inform developers with link to this page.</span>;
+      case 0:
+        return null;
+      case 1:
+        return <span>Version from <strong>{datesWithoutDiff[0]}</strong> is no longer in Versionista. {tooltip}</span>;
+      case 2:
+        return <span>Both versions are no longer in Versionista. {tooltip}</span>;
+      default:
+        return <span>Something unexpected happened. Please inform developers with link to this page.</span>;
     }
   }
 


### PR DESCRIPTION
Since we now have data coming from the Wayback Machine, it seems like it would be helpful to clarify what source the version you’re looking at came from. We don’t have a whole lot of room in these version selectors, so I’ve just added a `(V)` for Versionista and `(IA)` for Internet Archive. That’s both ugly and a bit cryptic, so if anyone has better ideas, let’s hear them!

![screen shot 2018-09-26 at 3 50 12 pm](https://user-images.githubusercontent.com/74178/46113708-5171a600-c1a4-11e8-9955-2ac5e0530dbd.png)

I’m thinking we’ll have more freedom to do something smarter and nicer whenever someone has time to revive #98.