### PR TITLE
Upgrade to Node v10.11.0 (current release)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.11.4
+      - image: circleci/node:10.11.0
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10.11.0
+      - image: circleci/node:10.12.0
     steps:
       - checkout
       - restore_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Baseline image for development/test/build ###
 # We require a lot of extras for building (Python, GCC) because of Node-Zopfli.
-FROM node:8.11.4 as dev
+FROM node:10.11.0 as dev
 MAINTAINER enviroDGI@gmail.com
 
 # apt-transport-https is needed to process yarn sources
@@ -39,7 +39,7 @@ RUN yarn run build-production
 ### Release Image ###
 # It might feel ridiculous to build up all the same things again, but the
 # resulting image is less than half the size!
-FROM node:8.11.4-slim as release
+FROM node:10.11.0-slim as release
 MAINTAINER enviroDGI@gmail.com
 
 # apt-transport-https is needed to process yarn sources

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Baseline image for development/test/build ###
 # We require a lot of extras for building (Python, GCC) because of Node-Zopfli.
-FROM node:10.11.0 as dev
+FROM node:10.12.0 as dev
 MAINTAINER enviroDGI@gmail.com
 
 # apt-transport-https is needed to process yarn sources
@@ -39,7 +39,7 @@ RUN yarn run build-production
 ### Release Image ###
 # It might feel ridiculous to build up all the same things again, but the
 # resulting image is less than half the size!
-FROM node:10.11.0-slim as release
+FROM node:10.12.0-slim as release
 MAINTAINER enviroDGI@gmail.com
 
 # apt-transport-https is needed to process yarn sources

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ It’s a React.js-based browser application with a Node.js backend with the foll
 
 ## Installation
 
-1. Install Node v10.11.0
-    - We recommend [installing Node Version Manager][nvm-install], then: `nvm install 10.11.0`
+1. Install Node v10.12.0
+    - We recommend [installing Node Version Manager][nvm-install], then: `nvm install 10.12.0`
     - If you are using Windows, check out [Nodenv][nodenv] or any of [these alternatives][nvm-alternatives].
 
 2. [Install][yarn-install] the `yarn` package manager.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ It’s a React.js-based browser application with a Node.js backend with the foll
 
 ## Installation
 
-1. Install Node v8.11.4
-    - We recommend [installing Node Version Manager][nvm-install], then: `nvm install 8.11.4`
+1. Install Node v10.11.0
+    - We recommend [installing Node Version Manager][nvm-install], then: `nvm install 10.11.0`
     - If you are using Windows, check out [Nodenv][nodenv] or any of [these alternatives][nvm-alternatives].
 
 2. [Install][yarn-install] the `yarn` package manager.

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "author": "",
   "license": "GPL-3.0",
   "engines": {
-    "node": "10.11.0"
+    "node": "10.12.0"
   },
   "browserslist": [
     "last 2 versions",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "author": "",
   "license": "GPL-3.0",
   "engines": {
-    "node": "8.11.4"
+    "node": "10.11.0"
   },
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
Node v10 has entered the LTS cycle, so it makes sense to update now. (We probably could have done this months ago and it would have been fine, but I guess I was being conservative.)