### PR TITLE
Auto-publish docker images from `release` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ workflows:
       - build:
           filters:
             branches:
-              ignore: master
+              ignore: release
 
   build-and-publish:
     jobs:
@@ -49,11 +49,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
-      - approve_docker_publish:
-          type: approval
-          requires:
-            - build
+                - release
       - publish_docker:
           requires:
-            - approve_docker_publish
+            - build


### PR DESCRIPTION
We talked through this in this week's dev meeting. It's basically the same as the changes already made for DB in edgi-govdata-archiving/web-monitoring-db#410. We’re giving up on the CircleCI “approval” mechanism and instead just publishing from a special branch.