### PR TITLE
Exempt the healthcheck endpoint from force_ssl.

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -32,11 +32,15 @@ function createErrorHandler (response) {
     response.status(error.status || 500).json(errorData);
   };
 }
+
+// If FORCE_SSL is true, redirect any non-SSL requests to https.
 if (process.env.FORCE_SSL && process.env.FORCE_SSL.toLowerCase() === 'true') {
+  // The /healthcheck route is exempted, to allow liveness/readiness probes
+  // to make requests internal to a deployment (inside SSL termination).
+  const exemptPaths = /^\/healthcheck\/?$/;
+
   app.use((request, response, next) => {
-    if (request.secure || request.headers['x-forwarded-proto'] === 'https' || request.route === '/healthcheck') {
-      // The /healthcheck route is exempted, to allow liveness/readiness probes
-      // to make requests internal to a deployment (inside SSL termination).
+    if (request.secure || request.headers['x-forwarded-proto'] === 'https' || exemptPaths.test(request.path)) {
       return next();
     }
     response.redirect(

--- a/server/app.js
+++ b/server/app.js
@@ -34,7 +34,9 @@ function createErrorHandler (response) {
 }
 if (process.env.FORCE_SSL && process.env.FORCE_SSL.toLowerCase() === 'true') {
   app.use((request, response, next) => {
-    if (request.secure || request.headers['x-forwarded-proto'] === 'https') {
+    if (request.secure || request.headers['x-forwarded-proto'] === 'https' || request.route === '/healthcheck') {
+      // The /healthcheck route is exempted, to allow liveness/readiness probes
+      // to make requests internal to a deployment (inside SSL termination).
       return next();
     }
     response.redirect(


### PR DESCRIPTION
This should allow Kubernetes liveness/readiness probes to make HTTP requests.

Related to https://github.com/edgi-govdata-archiving/web-monitoring-db/pull/418

Please review with skepticism, as I did not base this on any documented example.