### PR TITLE
Save diff settings locally (also add `LayeredStorage`)

### DIFF
--- a/src/components/change-view.jsx
+++ b/src/components/change-view.jsx
@@ -2,6 +2,7 @@ import AnnotationForm from './annotation-form';
 import DiffSettingsForm from './diff-settings-form';
 import {diffTypesFor} from '../constants/diff-types';
 import DiffView from './diff-view';
+import layeredStorage from '../scripts/layered-storage';
 import Loading from './loading';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -19,6 +20,7 @@ import {
 
 const collapsedViewStorage = 'WebMonitoring.ChangeView.collapsedView';
 const defaultDiffType = 'SIDE_BY_SIDE_RENDERED';
+const diffSettingsStorage = 'edgi.wm.ui.diff_settings';
 
 /**
  * @typedef ChangeViewProps
@@ -64,10 +66,7 @@ export default class ChangeView extends React.Component {
       annotation: {},
       change: null,
       collapsedView: true,
-      diffSettings: {
-        removeFormatting: false,
-        useWaybackResources: true,
-      },
+      diffSettings: loadDiffSettings(),
       diffType: undefined,
       updating: false,
     };
@@ -125,6 +124,9 @@ export default class ChangeView extends React.Component {
 
   handleDiffSettingsChange (diffSettings) {
     this.setState({diffSettings});
+    if (diffSettings) {
+      saveDiffSettings(diffSettings);
+    }
   }
 
   handleFromVersionChange (version) {
@@ -424,4 +426,15 @@ function mediaTypeForVersion (version, page) {
 function mediaTypeForUrl (url) {
   const extension = url ? url.match(extensionExpression) : null;
   return extension && mediaTypeForExtension[extension[2]];
+}
+
+function loadDiffSettings () {
+  return layeredStorage.getItem(diffSettingsStorage) || {
+    removeFormatting: false,
+    useWaybackResources: true,
+  };
+}
+
+function saveDiffSettings (settings) {
+  layeredStorage.setItem(diffSettingsStorage, settings);
 }

--- a/src/scripts/__tests__/layered-storage.test.js
+++ b/src/scripts/__tests__/layered-storage.test.js
@@ -1,0 +1,106 @@
+/* eslint-env jest */
+
+import {SafeStorage, LayeredStorage} from '../layered-storage';
+
+describe('LayeredStorage module', () => {
+  describe('SafeStorage class', () => {
+    test('SafeStorage should call through to getItem()', () => {
+      const data = {whatever: 'example'};
+      const storage = new SafeStorage({
+        getItem (key) { return data[key]; }
+      });
+
+      expect(storage.getItem('whatever')).toEqual('example');
+    });
+
+    test('SafeStorage should call through to setItem()', () => {
+      const data = {};
+      const storage = new SafeStorage({
+        setItem (key, value) { data[key] = value; }
+      });
+
+      storage.setItem('whatever', 'example');
+      expect(data).toHaveProperty('whatever', '"example"');
+    });
+
+    test('SafeStorage should not throw on setItem', () => {
+      const storage = new SafeStorage({
+        setItem () {
+          throw new DOMException('Cannot store stuff for some reason');
+        }
+      });
+
+      expect(storage.setItem('whatever')).toEqual(false);
+    });
+
+    test('SafeStorage should call through to clear()', () => {
+      let cleared = false;
+      const storage = new SafeStorage({
+        clear () { cleared = true; }
+      });
+
+      storage.clear();
+      expect(cleared).toEqual(true);
+    });
+
+    test('SafeStorage should call through to removeItem()', () => {
+      let calledWith = null;
+      const storage = new SafeStorage({
+        removeItem (key) { calledWith = key; }
+      });
+
+      storage.removeItem('whatever');
+      expect(calledWith).toEqual('whatever');
+    });
+
+    test('SafeStorage should serialize objects', () => {
+      let storedValue = null;
+      const storage = new SafeStorage({
+        setItem (key, value) { storedValue = value; }
+      });
+
+      storage.setItem('whatever', {somekey: 'somevalue'});
+      expect(storedValue).toEqual('{"somekey":"somevalue"}');
+    });
+
+    test('SafeStorage should deserialize objects', () => {
+      const storage = new SafeStorage({
+        getItem (key) { return '{"somekey":"somevalue"}'; }
+      });
+
+      expect(storage.getItem('whatever')).toEqual({somekey: 'somevalue'});
+    });
+
+    test('SafeStorage should not fail on non-JSON data', () => {
+      const storage = new SafeStorage({
+        getItem (key) { return 'Plain old string'; }
+      });
+
+      expect(storage.getItem('whatever')).toEqual('Plain old string');
+    });
+  });
+
+  describe('LayeredStorage class', () => {
+    test('LayeredStorage should getItem() from the first with a value', () => {
+      const storage = new LayeredStorage([
+        { getItem (key) { return null; } },
+        { getItem (key) { return 'a'; } },
+        { getItem (key) { return 'b'; } }
+      ]);
+
+      expect(storage.getItem('whatever')).toEqual('a');
+    });
+
+    test('LayeredStorage should setItem() on all layers', () => {
+      const called = [];
+      const storage = new LayeredStorage([
+        { setItem (key) { called.push('a'); } },
+        { setItem (key) { called.push('b'); } },
+        { setItem (key) { called.push('c'); } }
+      ]);
+
+      storage.setItem('whatever');
+      expect(called).toEqual(['a', 'b', 'c']);
+    });
+  });
+});

--- a/src/scripts/layered-storage.js
+++ b/src/scripts/layered-storage.js
@@ -1,0 +1,88 @@
+'use strict';
+
+/**
+ * Wraps a DOMStorage instance (e.g. sessionStorage or localStorage) so that
+ * you can save and load non-string values and so that you don't have to worry
+ * about catching exceptions (e.g. if the storage quota is exceeded).
+ */
+export class SafeStorage {
+  constructor (backingStore) {
+    this.store = backingStore;
+  }
+
+  get length () { return this.store.length; }
+
+  clear () { return this.store.clear(); }
+
+  getItem (key) {
+    const value = this.store.getItem(key);
+    try {
+      return (value == null || !value.length) ? value : JSON.parse(value);
+    }
+    catch (error) {
+      return value;
+    }
+  }
+
+  key (index) { return this.store.key(index); }
+
+  removeItem (key) { return this.store.removeItem(key); }
+
+  setItem (key, value) {
+    const actualValue = JSON.stringify(value);
+    try {
+      this.store.setItem(key, actualValue);
+      return true;
+    }
+    catch (error) {
+      return false;
+    }
+  }
+}
+
+/**
+ * Wrapper for a series of DOM Storage objects that saves data to all of them
+ * and reads data from the topmost store.
+ */
+export class LayeredStorage {
+  constructor (stores) {
+    this.stores = stores;
+  }
+
+  getItem (key) {
+    for (const store of this.stores) {
+      const value = store.getItem(key);
+      if (value != null) return value;
+    }
+  }
+
+  setItem (key, value) {
+    this.stores.reduce((success, store) => {
+      try {
+        store.setItem(key, value);
+        return success;
+      }
+      catch (error) {
+        return false;
+      }
+    }, true);
+  }
+
+  removeItem (key) {
+    this.stores.forEach(store => store.removeItem(key));
+  }
+
+  clear () {
+    this.stores.forEach(store => store.clear());
+  }
+}
+
+/**
+ * A DOM Storage instance that saves data in both session and local storage,
+ * so new browser windows have the data, but reads data from session storage,
+ * so concurrently open windows don't interfere with each other.
+ */
+export default new LayeredStorage([
+  new SafeStorage(sessionStorage),
+  new SafeStorage(localStorage)
+]);


### PR DESCRIPTION
This adds a new `layered-storage` module with three items:
- `SafeStorage` wraps DOMStorage objects so they don't throw exceptions and can accept complex objects.
- `LayeredStorage` combines multiple DOMStorage objects to save to all read from the first.
- `layeredStorage` is an instance of `LayeredStorage` stacking `SafeStorage` wrappers of session storage on top of local storage.

Then the `ChangeView` uses layered storage to save and load diff settings so they stick across page views.

It’s not super clean that all three of the above items are in one module, but I’m also not sure we need them independently (happy to change if someone thinks that’s worthwhile). Hopefully the way they are factored out allows us to make other modifications or add other types of storage pretty easily in the future.

We can also leverage this for #192.

Fixes #312.