### PR TITLE
HOTFIX: CVE-2018-16469

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7545,10 +7545,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-      "dev": true
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
     },
     "merge-descriptors": {
       "version": "1.0.1",


### PR DESCRIPTION
Updates the `merge` package to fix a security vulnerability. See NVD for more on this one; it's probably not too dangerous for us, but worth fixing: https://nvd.nist.gov/vuln/detail/CVE-2018-16469

New installs should automatically get the fixed version of `merge`. This just updates the lockfile for production and for people who already have dependencies installed.