### PR TITLE
Check version's `mime_type` if no `content_type` is present

### DIFF
--- a/src/components/change-view.jsx
+++ b/src/components/change-view.jsx
@@ -411,7 +411,8 @@ const extensionExpression = /^([^:]+:\/\/)?.*\/[^/]*(\.[^/]+)$/;
 
 function mediaTypeForVersion (version, page) {
   const contentType = version.content_type
-    || version.source_metadata.content_type;
+    || version.source_metadata.content_type
+    || version.source_metadata.mime_type;
 
   if (contentType) {
     return parseMediaType(contentType);


### PR DESCRIPTION
We determine the types of diffs available based on a version's `content_type`. Unfortunately, some sources have a `mime_type` instead. This just falls back to checking `mime_type` if no `content_type` exists, ensuring we show the right diff options in these cases.

Compare this new default diff view for plain text:

<img width="1280" alt="screen shot 2018-11-23 at 10 10 10 pm" src="https://user-images.githubusercontent.com/74178/48965254-64b7ac80-ef6e-11e8-96b6-18030fd3f985.png">

With the one in #322:

![screen shot 2018-11-21 at 9 04 50 am](https://user-images.githubusercontent.com/74178/48857949-02448d80-ed6f-11e8-84d8-11ecd8d7c1af.png)

Much more useful :)

Fixes #322.