### PR TITLE
Upgrade Node.js to 10.14.1 (2018-11 security update)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10.13.0
+      - image: circleci/node:10.14.1
     steps:
       - checkout
       - restore_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Baseline image for development/test/build ###
 # We require a lot of extras for building (Python, GCC) because of Node-Zopfli.
-FROM node:10.13.0 as dev
+FROM node:10.14.1 as dev
 MAINTAINER enviroDGI@gmail.com
 
 RUN mkdir -p /app
@@ -30,7 +30,7 @@ RUN npm run build-production
 ### Release Image ###
 # It might feel ridiculous to build up all the same things again, but the
 # resulting image is less than half the size!
-FROM node:10.13.0-slim as release
+FROM node:10.14.1-slim as release
 MAINTAINER enviroDGI@gmail.com
 
 # apt-get in this base image does not have dumb-init

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ It’s a React.js-based browser application with a Node.js backend with the foll
 
 ## Installation
 
-1. Install Node v10.13.0
-    - We recommend [installing Node Version Manager][nvm-install], then: `nvm install 10.13.0`
+1. Install Node v10.14.1
+    - We recommend [installing Node Version Manager][nvm-install], then: `nvm install 10.14.1`
     - If you are using Windows, check out [Nodenv][nodenv] or any of [these alternatives][nvm-alternatives].
 
 2. Install node dependencies with `npm`

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "author": "",
   "license": "GPL-3.0",
   "engines": {
-    "node": "10.13.0"
+    "node": "10.14.1"
   },
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
In a poorly timed PR, #324 upgraded Node.js a day before November security updates were released. So here's another upgrade. Since this is both pretty rote and comes so quickly after another Node.js update, I’m just going to merge this as soon as the 10.14.1 container becomes available on Circle.