### PR TITLE
Fix breakage of PageList when page has no versions

### DIFF
--- a/src/components/page-list.jsx
+++ b/src/components/page-list.jsx
@@ -87,7 +87,7 @@ export default class PageList extends React.Component {
 
     return (
       <tr key={record.uuid} onClick={onClick}>
-        <td>{dateFormatter.format(record.latest.capture_time)}</td>
+        <td>{record.latest ? dateFormatter.format(record.latest.capture_time) : 'No saved versions'}</td>
         <td>{formatSites(record.tags)}</td>
         <td>{record.title}</td>
         <td><a href={record.url} target="_blank" rel="noopener">{record.url}</a></td>


### PR DESCRIPTION
Fixes #174. 

Changes the `PageList` to display "No saved versions" in the "Capture Data" column:

<img width="932" alt="Screen Shot 2019-05-22 at 6 59 09 AM" src="https://user-images.githubusercontent.com/47554/58180577-338b1100-7c5f-11e9-897b-7deec6519af3.png">

I verified that the `PageDetails` does handle the state:

<img width="942" alt="Screen Shot 2019-05-22 at 6 59 17 AM" src="https://user-images.githubusercontent.com/47554/58180666-561d2a00-7c5f-11e9-8b6c-22834c70b2d8.png">
 