### PR TITLE
Move cutoff date for versions MUCH earlier

### DIFF
--- a/src/components/page-details.jsx
+++ b/src/components/page-details.jsx
@@ -5,7 +5,7 @@ import WebMonitoringDb from '../services/web-monitoring-db';
 import ChangeView from './change-view';
 import Loading from './loading';
 
-const cutoffDate = '2016-11-01';
+const cutoffDate = '2000-01-01';
 
 /**
  * @typedef {Object} PageDetailsProps


### PR DESCRIPTION
We need to view comparisons with versions earlier in the Obama administration, and for now, I'm not sure a cutoff really makes sense. This moves the cutoff date to January 1st, 2000.

Analysts need this ASAP for a report, so I’m going ahead and merging it. It’s pretty low risk.