### PR TITLE
Add production build task to CircleCI tests #287

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ jobs:
           paths:
             - ./node_modules
       - run:
+          name: Build
+          command: npm run build-production
+      - run:
           name: Run linter
           command: npm run lint
       - run:


### PR DESCRIPTION
Feel free to ignore this for now. Needed to make an early PR to trigger the Circle CI tests and will move the build task out as a separate job once I verify this actually works and doesn't blow up everything.