### PR TITLE
Parse Webpack config paths correctly on Windows

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ const context = __dirname;
 
 function removeSrcDirectory (filePath) {
   let relativePath = path.relative(context, filePath);
-  if (relativePath.startsWith('src/')) {
+  if (relativePath.startsWith('src' + path.sep)) {
     relativePath = relativePath.slice(4);
   }
   return relativePath;


### PR DESCRIPTION
We strip the `src` directory from some paths when building (for assets, like CSS, images, fonts, etc.), but we do that by looking for it using a posix-style path separator. That doesn't ever match when building on Windows (it *does* work inside WSL, just not in the normal Windows command line). Instead, use `path.sep` so we are checking with whatever the current system's path separator is.

We have some other posix-style paths in this file, but they mostly all get fixed and normalized at a lower level and work fine.

Found while testing #390.