### PR TITLE
Migrate pages search functionality into search-bar component

### DIFF
--- a/src/components/__tests__/search-bar-test.jsx
+++ b/src/components/__tests__/search-bar-test.jsx
@@ -1,0 +1,35 @@
+/* eslint-env jest */
+
+import React from 'react';
+import {shallow} from 'enzyme';
+import SearchBar from '../search-bar/search-bar';
+
+describe('search-bar', () => {
+  // Need to use a fake timer because the _dispatchSearch function is debounced
+  jest.useFakeTimers();
+  const onSearch = jest.fn();
+
+  it('Renders the search-bar', () => {
+    const searchBar = shallow(<SearchBar />);
+    const searchBarInput = searchBar.find('input');
+    expect(searchBarInput.prop('placeholder')).toBe('Search for a URL...');
+  });
+
+  it('Handles search queries with a protocol correctly', () => {
+    const searchBar = shallow(<SearchBar onSearch={onSearch} />);
+    const searchBarInput = searchBar.find('input');
+    searchBarInput.simulate('change', {target: {value: 'http://epa'}});
+
+    jest.runAllTimers();
+    expect(onSearch).toHaveBeenCalledWith({url: 'http://epa*'});
+  });
+
+  it('Handles search queries without a protocol correctly', () => {
+    const searchBar = shallow(<SearchBar onSearch={onSearch} />);
+    const searchBarInput = searchBar.find('input');
+    searchBarInput.simulate('change', {target: {value: 'epa'}});
+
+    jest.runAllTimers();
+    expect(onSearch).lastCalledWith({url: '*//epa*'});
+  });
+});

--- a/src/components/page-list.jsx
+++ b/src/components/page-list.jsx
@@ -1,6 +1,7 @@
 import {dateFormatter, formatSites} from '../scripts/formatters';
 import Loading from './loading';
 import React from 'react';
+import SearchBar from './search-bar/search-bar';
 
 /**
  * These props also inherit from React Router's RouteComponent props
@@ -17,12 +18,6 @@ import React from 'react';
  * @param {PageListProps} props
  */
 export default class PageList extends React.Component {
-  constructor (props) {
-    super(props);
-    this._didSearch = this._didSearch.bind(this);
-    this._dispatchSearch = debounce(this._dispatchSearch.bind(this), 500);
-  }
-
   render () {
     if (!this.props.pages) {
       return <Loading />;
@@ -42,13 +37,7 @@ export default class PageList extends React.Component {
 
     return (
       <div className="container-fluid container-list-view">
-        <div className="row search-bar">
-          <input
-            type="text"
-            placeholder="Search for a URL..."
-            onChange={this._didSearch}
-          />
-        </div>
+        <SearchBar onSearch={this.props.onSearch} />
         {results}
       </div>
     );
@@ -113,28 +102,6 @@ export default class PageList extends React.Component {
 
     this.props.history.push(`/page/${page.uuid}`);
   }
-
-  _didSearch (event) {
-    this._dispatchSearch(event.target.value);
-  }
-
-  _dispatchSearch (url) {
-    if (url) {
-      // If doesn't start with a protocol (or looks like it's going that way),
-      // prefix with an asterisk.
-      if (!/^(\*|\/\/|(h|ht|htt|https?|https?\/|https?\/\/))/.test(url)) {
-        url = url = `*//${url}`;
-      }
-      // If the search is for a domain + TLD, return all paths under it
-      if (/^[\w:*]+(\/\/)?[^/]+$/.test(url)) {
-        url = `${url}*`;
-      }
-    }
-    if (this.props.onSearch) {
-      const query = url ? {url} : null;
-      this.props.onSearch(query);
-    }
-  }
 }
 
 function isInAnchor (node) {
@@ -145,12 +112,4 @@ function isInAnchor (node) {
     return true;
   }
   return isInAnchor(node.parentNode);
-}
-
-function debounce (func, delay) {
-  let timer = null;
-  return function (...args) {
-    clearTimeout(timer);
-    timer = setTimeout(() => func(...args), delay);
-  };
 }

--- a/src/components/search-bar/search-bar.css
+++ b/src/components/search-bar/search-bar.css
@@ -1,0 +1,11 @@
+.search-bar {
+  border-bottom: 1px solid #ccc;
+  margin-bottom: 0.5em;
+}
+
+.search-bar-input {
+  border: none;
+  font-size: 1.25em;
+  padding: 0.5em 15px;
+  width: 100%;
+}

--- a/src/components/search-bar/search-bar.jsx
+++ b/src/components/search-bar/search-bar.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import './search-bar.css';
+
+/**
+ * @typedef SearchBarProps
+ * @property {(any) => void} onSearch
+ */
+
+/**
+ * Renders input to handle page url search functionality and calls search query.
+ *
+ * @class SearchBar
+ * @extends {React.Component}
+ * @param {SearchBarProps} props
+ */
+export default class SearchBar extends React.Component {
+  constructor(props) {
+    super(props);
+    this._didSearch = this._didSearch.bind(this);
+    this._dispatchSearch = debounce(this._dispatchSearch.bind(this), 500);
+  }
+
+  _didSearch (event) {
+    this._dispatchSearch(event.target.value);
+  }
+
+  _dispatchSearch (url) {
+    if (url) {
+      // If doesn't start with a protocol (or looks like it's going that way),
+      // prefix with an asterisk.
+      if (!/^(\*|\/\/|(h|ht|htt|https?|https?\/|https?\/\/))/.test(url)) {
+        url = url = `*//${url}`;
+      }
+      // If the search is for a domain + TLD, return all paths under it
+      if (/^[\w:*]+(\/\/)?[^/]+$/.test(url)) {
+        url = `${url}*`;
+      }
+    }
+    if (this.props.onSearch) {
+      const query = url ? {url} : null;
+      this.props.onSearch(query);
+    }
+  }
+
+  render() {
+    return (
+      <div className="row" styleName="search-bar">
+        <input
+          styleName="search-bar-input"
+          type="text"
+          placeholder="Search for a URL..."
+          onChange={this._didSearch}
+        />
+      </div>
+    );
+  }
+}
+
+function debounce (func, delay) {
+  let timer = null;
+  return function (...args) {
+    clearTimeout(timer);
+    timer = setTimeout(() => func(...args), delay);
+  };
+}

--- a/src/components/source-info/source-info.jsx
+++ b/src/components/source-info/source-info.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import './source-info.css';
 
 /**
- * @typedef SourceInfo
+ * @typedef SourceInfoProps
  * @property {Version} from
  * @property {Version} to
  * @property {String} pageUrl
@@ -43,7 +43,7 @@ export default class SourceInfo extends React.Component {
       const fromLink = (
         <li styleName="source-info-list-item" key={this.props.from.source_metadata.view_url}>
           <span aria-hidden="true"> | </span>
-          <a 
+          <a
             styleName="source-info-link"
             href={this.props.from.source_metadata.view_url}
             target="_blank"
@@ -54,7 +54,7 @@ export default class SourceInfo extends React.Component {
           </a>
         </li>
       );
-      
+
       links.push(fromLink);
     }
 
@@ -73,10 +73,10 @@ export default class SourceInfo extends React.Component {
           </a>
         </li>
       );
-      
+
       links.push(toLink);
     }
-    
+
     return (
       <aside>
         <ol styleName="source-info-list">

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -160,18 +160,6 @@ body {
   width: 40%;
 }
 
-.search-bar {
-  border-bottom: 1px solid #ccc;
-  margin-bottom: 0.5em;
-}
-
-.search-bar input {
-  border: none;
-  font-size: 1.25em;
-  padding: 0.5em 15px;
-  width: 100%;
-}
-
 /* ===== Page Detail View ===== */
 .page-title {
   font-size: 1.5em;


### PR DESCRIPTION
This PR moves the search functionality out of `page-list` into its own self-contained component, `search-bar`. This seems like a smart thing to do before new search queries are added which would bloat `page-list` if this isn't refactored, so I view this PR as a precursor to #81. 

Lmk what you think. I will also be adding more rigorous tests after I get initial feedback.

**Search still seems to work as expected:**
<img width="1435" alt="Screen Shot 2019-09-21 at 6 23 29 PM" src="https://user-images.githubusercontent.com/10149117/65381056-9c31db00-dc9d-11e9-9967-e83d0785090c.png">
