### PR TITLE
Document public user credentials on staging DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,9 @@
 # If you are developing the API locally, set this to the URL of your local web-monitoring-db instance
+# EDGI's staging database (good for testing!) is:
+#     https://api-staging.monitoring.envirodatagov.org
+# And you can use the public account's login credentials on it:
+#     Username: public.access@envirodatagov.org
+#     Password: PUBLIC_ACCESS
 WEB_MONITORING_DB_URL=https://api-staging.monitoring.envirodatagov.org
 
 # Redirect all HTTP requests to https (you probably want this off in development)

--- a/README.md
+++ b/README.md
@@ -28,13 +28,18 @@ It’s a React.js-based browser application with a Node.js backend with the foll
 
 3. Copy `.env.example` to `.env` and supply any local configuration info you need (all fields are optional)
 
-4. Start the web server
+4. (Optional) Set up Google Sheets for saving important changes and repeated, “dictionary” changes. See the section below on [Google Sheets](#google-sheets-tasking-and-significant-changes).
+
+5. Start the web server!
 
     ```sh
     npm start
     ```
 
-5. (Optional) Set up Google Sheets for saving important changes and repeated, “dictionary” changes. See the section below on [Google Sheets](#google-sheets-tasking-and-significant-changes).
+    …and point your browser to http://localhost:3001 to view the app. If you haven't changed `WEB_MONITORING_DB_URL` in your `.env` file (step 3), you can log in with the public user credentials:
+
+    - Username: `public.access@envirodatagov.org`
+    - Password: `PUBLIC_ACCESS`
 
 [nodenv]: https://github.com/nodenv/nodenv
 [nvm-alternatives]: https://github.com/nodenv/nodenv/wiki/Alternatives

--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ It’s a React.js-based browser application with a Node.js backend with the foll
 
 3. Copy `.env.example` to `.env` and supply any local configuration info you need (all fields are optional)
 
-4. (Optional) Set up Google Sheets for saving important changes and repeated, “dictionary” changes. See the section below on [Google Sheets](#google-sheets-tasking-and-significant-changes).
-
-5. Start the web server!
+4. Start the web server!
 
     ```sh
     npm start
@@ -40,6 +38,8 @@ It’s a React.js-based browser application with a Node.js backend with the foll
 
     - Username: `public.access@envirodatagov.org`
     - Password: `PUBLIC_ACCESS`
+
+5. (Optional) Set up Google Sheets for saving important changes and repeated, “dictionary” changes. See the section below on [Google Sheets](#google-sheets-tasking-and-significant-changes).
 
 [nodenv]: https://github.com/nodenv/nodenv
 [nvm-alternatives]: https://github.com/nodenv/nodenv/wiki/Alternatives


### PR DESCRIPTION
With default settings, the UI uses the staging DB for its data, and that database has a “public access” user with credentials anybody can use. We don’t document that here, though! This adds info about those credentials to the both the `.env.example` file and the setup guide in the README.