### PR TITLE
Narrow the scope of browsers we compile JS for

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,12 @@
 {
   "presets": [
     ["@babel/preset-env", {
-      "targets": {
-        "browsers": [
-          "last 2 versions",
-          "not Explorer < 11",
-          "not ExplorerMobile > 0"
-        ]
-      }
+      // Uncomment to check query results when building.
+      // "debug": true,
+
+      // Preview the results of this query at:
+      // https://browserl.ist/?q=last+3+versions%2C+not+%3C+1%25%2C+not+ie+%3C+100%2C+not+op_mini+all
+      "targets": "last 3 versions, not < 1%, not ie < 100, not op_mini all"
     }],
     "@babel/preset-react"
   ],


### PR DESCRIPTION
We previously compiled for a pretty broad group of browsers, including ones we don't really test in and that I don’t think were actually well supported in our code anyway (e.g. IE 11, Opera Mini, Android Browser [no longer maintained!], Blackberry Browser, etc.). This narrows the range a lot, but given the complete dynamic nature of the site and how little capacity we have for broad testing, I think that's ok.

There’s a decent article about the problems with queries like had I ran across a while back: https://jamie.build/last-2-versions

You can also preview what browsers this covers at https://browserl.ist/?q=last+3+versions%2C+not+%3C+1%25%2C+not+ie+%3C+100%2C+not+op_mini+all (Feel free to play around and suggest a different query if you think one might be better.)

It also reduces our production JS size from 287 kB to 249 kB (or 70 kB gzipped).

Finally, the `targets.browsers` property is being deprecated in `babel-preset-env`, so I’ve switched to the simple, single-string query, too: https://babeljs.io/docs/en/next/babel-preset-env.html#targetsbrowsers

Previously included plugins:

```
transform-template-literals { "android":"67", "ie":"11", "ios":"12", "opera":"12.1", "safari":"12" }
transform-literals { "android":"67", "ie":"11", "opera":"12.1" }
transform-function-name { "android":"67", "edge":"17", "ie":"11", "opera":"12.1" }
transform-arrow-functions { "android":"67", "ie":"11", "opera":"12.1" }
transform-block-scoped-functions { "android":"67", "opera":"12.1" }
transform-classes { "android":"67", "ie":"11", "opera":"12.1" }
transform-object-super { "android":"67", "ie":"11", "opera":"12.1" }
transform-shorthand-properties { "android":"67", "ie":"11", "opera":"12.1" }
transform-duplicate-keys { "android":"67", "ie":"11", "opera":"12.1" }
transform-computed-properties { "android":"67", "ie":"11", "opera":"12.1" }
transform-for-of { "android":"67", "ie":"11", "opera":"12.1" }
transform-sticky-regex { "android":"67", "ie":"11", "opera":"12.1" }
transform-dotall-regex { "android":"67", "edge":"17", "firefox":"67", "ie":"11", "opera":"12.1" }
transform-unicode-regex { "android":"67", "ie":"11", "opera":"12.1" }
transform-spread { "android":"67", "ie":"11", "opera":"12.1" }
transform-parameters { "android":"67", "edge":"17", "ie":"11", "opera":"12.1" }
transform-destructuring { "android":"67", "ie":"11", "opera":"12.1" }
transform-block-scoping { "android":"67", "ie":"11", "opera":"12.1" }
transform-typeof-symbol { "android":"67", "ie":"11", "opera":"12.1" }
transform-new-target { "android":"67", "ie":"11", "opera":"12.1" }
transform-regenerator { "android":"67", "ie":"11", "opera":"12.1" }
transform-exponentiation-operator { "android":"67", "ie":"11", "opera":"12.1" }
transform-async-to-generator { "android":"67", "ie":"11", "opera":"12.1" }
proposal-async-generator-functions { "android":"67", "edge":"17", "ie":"11", "opera":"12.1" }
proposal-object-rest-spread { "android":"67", "edge":"17", "ie":"11", "opera":"12.1" }
proposal-unicode-property-regex { "android":"67", "edge":"17", "firefox":"67", "ie":"11", "opera":"12.1", "samsung":"8.2" }
proposal-json-strings { "android":"67", "edge":"17", "ie":"11", "opera":"12.1", "samsung":"8.2" }
proposal-optional-catch-binding { "android":"67", "edge":"17", "ie":"11", "opera":"12.1", "samsung":"8.2" }
transform-named-capturing-groups-regex { "android":"67", "edge":"17", "firefox":"67", "ie":"11", "opera":"12.1", "samsung":"8.2" }
```

Included now:

```
transform-template-literals { "ios":"12", "safari":"12.1" }
transform-function-name { "edge":"17" }
transform-dotall-regex { "edge":"17", "firefox":"67" }
transform-parameters { "edge":"17" }
proposal-async-generator-functions { "edge":"17" }
proposal-object-rest-spread { "edge":"17" }
proposal-unicode-property-regex { "edge":"17", "firefox":"67", "samsung":"9.2" }
proposal-json-strings { "edge":"17", "samsung":"9.2" }
proposal-optional-catch-binding { "edge":"17", "samsung":"9.2" }
transform-named-capturing-groups-regex { "edge":"17", "firefox":"67", "samsung":"9.2" }
```