### PR TITLE
Migrate login-form styles to use CSS Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ This project wouldn’t exist without a lot of amazing people’s help. Thanks t
 | [💻](# "Code") [📖](# "Documentation") [💬](# "Answering Questions") [👀](# "Reviewer") | [Rob Brackett](https://github.com/Mr0grog) |
 | [📖](# "Documentation") | [Patrick Connolly](https://github.com/patcon) |
 | [📖](# "Documentation") | [Manaswini Das](https://github.com/manaswinidas) |
+| [💻](# "Code") [⚠️](# "Tests") | [Nick Echols](https://github.com/steryereo) |
 | [💻](# "Code") [⚠️](# "Tests") | [Katie Jones](https://github.com/katjone) |
 | [💡](# "Examples") | [@lh00000000](https://github.com/lh00000000) |
 | [💻](# "Code") | [Greg Merrill](https://github.com/g-merrill) |

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -3,6 +3,7 @@
     "react"
   ],
   "parserOptions": {
+    "ecmaVersion": 8,
     "ecmaFeatures": {
       "jsx": true
     }

--- a/src/components/__tests__/login-form-test.jsx
+++ b/src/components/__tests__/login-form-test.jsx
@@ -1,0 +1,132 @@
+/* eslint-env jest */
+
+import React from 'react';
+import {shallow} from 'enzyme';
+import LoginPanel from '../logIn-form/logIn-form';
+import WebMonitoringDb from '../../services/web-monitoring-db';
+
+describe('login-form', () => {
+  const waitForNextTurn = () => new Promise(resolve => setTimeout(resolve, 0));
+
+  const getMockedApi = (overrides={}) => Object.assign(
+    Object.create(WebMonitoringDb.prototype),
+    overrides
+  );
+
+  it('Renders a form', () => {
+    const panel = shallow(<LoginPanel />);
+    expect(panel.find('form').length).toBe(1);
+  });
+
+  it('Renders a header', () => {
+    const panel = shallow(<LoginPanel />);
+    expect(panel.find('h1').text()).toBe('Log In');
+  });
+
+  it('Renders an info message', () => {
+    const panel = shallow(<LoginPanel />);
+    expect(panel.find('p.alert.alert-info').text())
+      .toBe('You must be logged in to view pages');
+  });
+
+  it('Renders a label and input for email', () => {
+    const panel = shallow(<LoginPanel />);
+    const label = panel.find('label').at(0);
+
+    expect(label.text()).toBe('E-mail Address:');
+    expect(label.find('input').props()).toMatchObject({type: 'text', name: 'email'});
+  });
+
+  it('Renders a label and input for password', () => {
+    const panel = shallow(<LoginPanel />);
+    const label = panel.find('label').at(1);
+
+    expect(label.text()).toBe('Password:');
+    expect(label.find('input').props()).toMatchObject({type: 'password', name: 'password'});
+  });
+
+  it('Renders a submit button for the form', () => {
+    const panel = shallow(<LoginPanel />);
+    expect(panel.find('form input[type="submit"]').length).toBe(1);
+  });
+
+  it('Renders a cancel button', () => {
+    const panel = shallow(<LoginPanel />);
+    expect(panel.findWhere(el => el.type() === 'button' && el.text() === 'Cancel').length).toBe(1);
+  });
+
+  it('Calls props.cancelLogin when the cancel button is clicked', () => {
+    const cancelLogin = jest.fn();
+    const panel = shallow(<LoginPanel cancelLogin={cancelLogin} />);
+    const cancelButton = panel.findWhere(el => el.type() === 'button' && el.text() === 'Cancel');
+
+    cancelButton.simulate('click', {preventDefault: () => {}});
+    expect(cancelLogin).toHaveBeenCalled();
+  });
+
+  describe('when the form is submitted', () => {
+    it('Calls "logIn" on the api service if email and password are present', () => {
+      const api = getMockedApi({logIn: jest.fn(() => Promise.resolve({}))});
+      const panel = shallow(<LoginPanel />, {context: {api}});
+
+      panel.find('input[name="email"]')
+        .simulate('change', {currentTarget: {value: 'aaa@aaa.aaa'}});
+      panel.find('input[name="password"]')
+        .simulate('change', {currentTarget: {value: 'password'}});
+
+      panel.find('form').simulate('submit', {preventDefault: () => {}});
+
+      expect(api.logIn).toHaveBeenCalledWith('aaa@aaa.aaa', 'password');
+    });
+
+    it('Calls props.onLogin if the api call is successful', () => {
+      const onLogin = jest.fn();
+      const panel = shallow(
+        <LoginPanel onLogin={onLogin} />,
+        {context: {api: getMockedApi({logIn: () => Promise.resolve({id: 5})})}}
+      );
+
+      panel.find('input[name="email"]')
+        .simulate('change', {currentTarget: {value: 'aaa@aaa.aaa'}});
+      panel.find('input[name="password"]')
+        .simulate('change', {currentTarget: {value: 'password'}});
+
+      panel.find('form').simulate('submit', {preventDefault: () => {}});
+
+      waitForNextTurn().then(() => {
+        expect(onLogin).toHaveBeenCalledWith({id: 5});
+      });
+    });
+
+    it('Displays an error if the api call is unsuccessful', () => {
+      const onLogin = jest.fn();
+      const api = getMockedApi({logIn: () => Promise.reject(new Error('Login unsuccessful'))});
+      const panel = shallow(<LoginPanel onLogin={onLogin} />, {context: {api}});
+
+      panel.find('input[name="email"]')
+        .simulate('change', {currentTarget: {value: 'aaa@aaa.aaa'}});
+      panel.find('input[name="password"]')
+        .simulate('change', {currentTarget: {value: 'password'}});
+
+      panel.find('form').simulate('submit', {preventDefault: () => {}});
+
+      waitForNextTurn().then(() => {
+        expect(panel.find('.alert.alert-danger').text()).toBe('Login unsuccessful');
+      });
+    });
+
+    it('Does not call "logIn" if email and password are not both present', () => {
+      const api = getMockedApi({logIn: jest.fn(() => Promise.resolve({}))});
+      const panel = shallow(<LoginPanel />, {context: {api}});
+
+      panel.find('input[name="email"]')
+        .simulate('change', {currentTarget: {value: 'aaa@aaa.aaa'}});
+
+      panel.find('form').simulate('submit', {preventDefault: () => {}});
+
+      expect(api.logIn).not.toHaveBeenCalled();
+      expect(panel.find('.alert.alert-danger').text())
+        .toBe('Please enter an e-mail and password.');
+    });
+  });
+});

--- a/src/components/__tests__/login-form-test.jsx
+++ b/src/components/__tests__/login-form-test.jsx
@@ -6,43 +6,25 @@ import LoginPanel from '../login-form/login-form';
 import WebMonitoringDb from '../../services/web-monitoring-db';
 
 describe('login-form', () => {
-  const waitForNextTurn = () => new Promise(resolve => setTimeout(resolve, 0));
-
   const getMockedApi = (overrides={}) => Object.assign(
     Object.create(WebMonitoringDb.prototype),
     overrides
   );
 
-  it('Renders a form', () => {
-    const panel = shallow(<LoginPanel />);
-    expect(panel.find('form').length).toBe(1);
-  });
-
-  it('Renders a header', () => {
-    const panel = shallow(<LoginPanel />);
-    expect(panel.find('h1').text()).toBe('Log In');
-  });
-
-  it('Renders an info message', () => {
-    const panel = shallow(<LoginPanel />);
-    expect(panel.find('p.alert.alert-info').text())
-      .toBe('You must be logged in to view pages');
-  });
-
   it('Renders a label and input for email', () => {
     const panel = shallow(<LoginPanel />);
     const label = panel.find('label').at(0);
 
-    expect(label.text()).toBe('E-mail Address:');
-    expect(label.find('input').props()).toMatchObject({type: 'text', name: 'email'});
+    expect(label.text()).toMatch(/e-?mail/i);
+    expect(label.find('input').props().type).toBe('text');
   });
 
   it('Renders a label and input for password', () => {
     const panel = shallow(<LoginPanel />);
     const label = panel.find('label').at(1);
 
-    expect(label.text()).toBe('Password:');
-    expect(label.find('input').props()).toMatchObject({type: 'password', name: 'password'});
+    expect(label.text()).toMatch(/password/i);
+    expect(label.find('input').props().type).toBe('password');
   });
 
   it('Renders a submit button for the form', () => {
@@ -52,21 +34,21 @@ describe('login-form', () => {
 
   it('Renders a cancel button', () => {
     const panel = shallow(<LoginPanel />);
-    expect(panel.findWhere(el => el.type() === 'button' && el.text() === 'Cancel').length).toBe(1);
+    expect(panel.findWhere(el => el.type() === 'button' && (/cancel/i).test(el.text())).length).toBe(1);
   });
 
   it('Calls props.cancelLogin when the cancel button is clicked', () => {
     const cancelLogin = jest.fn();
     const panel = shallow(<LoginPanel cancelLogin={cancelLogin} />);
-    const cancelButton = panel.findWhere(el => el.type() === 'button' && el.text() === 'Cancel');
+    const cancelButton = panel.findWhere(el => el.type() === 'button' && (/cancel/i).test(el.text()));
 
-    cancelButton.simulate('click', {preventDefault: () => {}});
+    cancelButton.simulate('click', document.createEvent('UIEvents'));
     expect(cancelLogin).toHaveBeenCalled();
   });
 
   describe('when the form is submitted', () => {
     it('Calls "logIn" on the api service if email and password are present', () => {
-      const api = getMockedApi({logIn: jest.fn(() => Promise.resolve({}))});
+      const api = getMockedApi({logIn: jest.fn().mockResolvedValue({})});
       const panel = shallow(<LoginPanel />, {context: {api}});
 
       panel.find('input[name="email"]')
@@ -74,33 +56,15 @@ describe('login-form', () => {
       panel.find('input[name="password"]')
         .simulate('change', {currentTarget: {value: 'password'}});
 
-      panel.find('form').simulate('submit', {preventDefault: () => {}});
+      panel.find('form').simulate('submit', document.createEvent('UIEvents'));
 
       expect(api.logIn).toHaveBeenCalledWith('aaa@aaa.aaa', 'password');
     });
 
-    it('Calls props.onLogin if the api call is successful', () => {
+    it('Calls props.onLogin if the api call is successful', async () => {
       const onLogin = jest.fn();
-      const panel = shallow(
-        <LoginPanel onLogin={onLogin} />,
-        {context: {api: getMockedApi({logIn: () => Promise.resolve({id: 5})})}}
-      );
+      const api = getMockedApi({logIn: jest.fn().mockResolvedValue({id: 5})});
 
-      panel.find('input[name="email"]')
-        .simulate('change', {currentTarget: {value: 'aaa@aaa.aaa'}});
-      panel.find('input[name="password"]')
-        .simulate('change', {currentTarget: {value: 'password'}});
-
-      panel.find('form').simulate('submit', {preventDefault: () => {}});
-
-      waitForNextTurn().then(() => {
-        expect(onLogin).toHaveBeenCalledWith({id: 5});
-      });
-    });
-
-    it('Displays an error if the api call is unsuccessful', () => {
-      const onLogin = jest.fn();
-      const api = getMockedApi({logIn: () => Promise.reject(new Error('Login unsuccessful'))});
       const panel = shallow(<LoginPanel onLogin={onLogin} />, {context: {api}});
 
       panel.find('input[name="email"]')
@@ -108,25 +72,45 @@ describe('login-form', () => {
       panel.find('input[name="password"]')
         .simulate('change', {currentTarget: {value: 'password'}});
 
-      panel.find('form').simulate('submit', {preventDefault: () => {}});
+      panel.find('form').simulate('submit', document.createEvent('UIEvents'));
 
-      waitForNextTurn().then(() => {
-        expect(panel.find('.alert.alert-danger').text()).toBe('Login unsuccessful');
-      });
+      // we have asserted that api.logIn gets called in the previous test.
+      // this waits for it to resolve before testing that onLogin gets called
+      await api.logIn.mock.results[0].value;
+      expect(onLogin).toHaveBeenCalledWith({id: 5});
+    });
+
+    it('Displays an error if the api call is unsuccessful', async () => {
+      const onLogin = jest.fn();
+      const api = getMockedApi({logIn: jest.fn().mockRejectedValue(new Error('Login unsuccessful'))});
+      const panel = shallow(<LoginPanel onLogin={onLogin} />, {context: {api}});
+
+      panel.find('input[name="email"]')
+        .simulate('change', {currentTarget: {value: 'aaa@aaa.aaa'}});
+      panel.find('input[name="password"]')
+        .simulate('change', {currentTarget: {value: 'password'}});
+
+      panel.find('form').simulate('submit', document.createEvent('UIEvents'));
+
+      try {
+        await api.logIn.mock.results[0].value;
+        throw new Error('api.logIn should have rejected'); // failsafe to make sure the assertion runs
+      } catch (err) {
+        expect(panel.find('.alert.alert-danger').text()).toBe(err.message);
+      }
     });
 
     it('Does not call "logIn" if email and password are not both present', () => {
-      const api = getMockedApi({logIn: jest.fn(() => Promise.resolve({}))});
+      const api = getMockedApi({logIn: jest.fn().mockResolvedValue({})});
       const panel = shallow(<LoginPanel />, {context: {api}});
 
       panel.find('input[name="email"]')
         .simulate('change', {currentTarget: {value: 'aaa@aaa.aaa'}});
 
-      panel.find('form').simulate('submit', {preventDefault: () => {}});
+      panel.find('form').simulate('submit', document.createEvent('UIEvents'));
 
       expect(api.logIn).not.toHaveBeenCalled();
-      expect(panel.find('.alert.alert-danger').text())
-        .toBe('Please enter an e-mail and password.');
+      expect(panel.find('.alert.alert-danger').text()).toBeTruthy();
     });
   });
 });

--- a/src/components/__tests__/login-form-test.jsx
+++ b/src/components/__tests__/login-form-test.jsx
@@ -16,7 +16,7 @@ describe('login-form', () => {
     const label = panel.find('label').at(0);
 
     expect(label.text()).toMatch(/e-?mail/i);
-    expect(label.find('input').props().type).toBe('text');
+    expect(label.find('input').props()).toMatchObject({name: 'email', type: 'text'});
   });
 
   it('Renders a label and input for password', () => {
@@ -24,7 +24,7 @@ describe('login-form', () => {
     const label = panel.find('label').at(1);
 
     expect(label.text()).toMatch(/password/i);
-    expect(label.find('input').props().type).toBe('password');
+    expect(label.find('input').props()).toMatchObject({name: 'password', type: 'password'});
   });
 
   it('Renders a submit button for the form', () => {
@@ -92,12 +92,8 @@ describe('login-form', () => {
 
       panel.find('form').simulate('submit', document.createEvent('UIEvents'));
 
-      try {
-        await api.logIn.mock.results[0].value;
-        throw new Error('api.logIn should have rejected'); // failsafe to make sure the assertion runs
-      } catch (err) {
-        expect(panel.find('.alert.alert-danger').text()).toBe(err.message);
-      }
+      await expect(api.logIn.mock.results[0].value).rejects.toThrow();
+      expect(panel.find('.alert.alert-danger').text()).toBe('Login unsuccessful');
     });
 
     it('Does not call "logIn" if email and password are not both present', () => {

--- a/src/components/__tests__/login-form-test.jsx
+++ b/src/components/__tests__/login-form-test.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import {shallow} from 'enzyme';
-import LoginPanel from '../logIn-form/logIn-form';
+import LoginPanel from '../login-form/login-form';
 import WebMonitoringDb from '../../services/web-monitoring-db';
 
 describe('login-form', () => {

--- a/src/components/login-form/login-form.css
+++ b/src/components/login-form/login-form.css
@@ -1,0 +1,15 @@
+.form {
+  width: 24em;
+}
+
+.title {
+  margin: 0 0 1em;
+}
+
+.group {
+  width: 100%;
+}
+
+.footer {
+  text-align: right;
+}

--- a/src/components/login-form/login-form.jsx
+++ b/src/components/login-form/login-form.jsx
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import WebMonitoringDb from '../services/web-monitoring-db';
+import WebMonitoringDb from '../../services/web-monitoring-db';
+import './login-form.css';
 
-/**
+/**s
  * @typedef {Object} LoginFormProps
  * @property {Function} cancelLogin Should match `() => void`
  * @property {Function} onLogin Callback when a user has logged in successfully.
@@ -35,27 +36,27 @@ export default class LoginPanel extends React.Component {
 
   render () {
     return (
-      <form className="login-form" onSubmit={this._logIn}>
-        <h1>Log In</h1>
+      <form styleName="form" onSubmit={this._logIn}>
+        <h1 styleName="title">Log In</h1>
         <p className="alert alert-info" role="alert">
           You must be logged in to view pages
         </p>
         {this._renderError()}
 
-        <label className="form-group">
+        <label className="form-group" styleName="group">
           <span className="info-text">E-mail Address:</span>
           <input className="form-control" type="text" name="email" onChange={this._updateEmail} />
         </label>
 
-        <label className="form-group">
+        <label className="form-group" styleName="group">
           <span className="info-text">Password:</span>
           <input className="form-control" type="password" name="password" onChange={this._updatePassword} />
         </label>
 
-        <div className="login-form__footer">
-          <input className="login-form__submit btn btn-primary" type="submit" value="Log In" />
+        <div styleName="footer">
+          <input className="btn btn-primary" type="submit" value="Log In" />
           {' '}
-          <button className="login-form__cancel btn btn-default" onClick={this._cancel}>Cancel</button>
+          <button className="btn btn-default" onClick={this._cancel}>Cancel</button>
         </div>
       </form>
     );

--- a/src/components/login-form/login-form.jsx
+++ b/src/components/login-form/login-form.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import WebMonitoringDb from '../../services/web-monitoring-db';
 import './login-form.css';
 
-/**s
+/**
  * @typedef {Object} LoginFormProps
  * @property {Function} cancelLogin Should match `() => void`
  * @property {Function} onLogin Callback when a user has logged in successfully.

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -6,7 +6,7 @@ import WebMonitoringApi from '../services/web-monitoring-api';
 import WebMonitoringDb from '../services/web-monitoring-db';
 import EnvironmentBanner from './environment-banner/environment-banner';
 import Loading from './loading';
-import LoginForm from './login-form';
+import LoginForm from './login-form/login-form';
 import NavBar from './nav-bar';
 import PageDetails from './page-details';
 import PageList from './page-list/page-list';
@@ -89,7 +89,7 @@ export default class WebMonitoringUi extends React.Component {
         }
 
         const query = Object.assign({include_latest: true}, this.state.search);
-        
+
         return api.getPages(query);
       })
       // Set state.pages = error; downstream code should check `pages` type.

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -380,27 +380,11 @@ iframe {
   }
 }
 
-/* ===== Login Form ===== */
+/* ===== Login Form Dialog ===== */
 .dialog__body {
   background: white;
   border-radius: 3px;
   padding: 1em;
-}
-
-.login-form {
-  width: 24em;
-}
-
-.login-form h1 {
-  margin: 0 0 1em;
-}
-
-.login-form .form-group {
-  width: 100%;
-}
-
-.login-form__footer {
-  text-align: right;
 }
 
 .loading {


### PR DESCRIPTION
before: 
![Screen Shot 2019-11-22 at 7 04 00 PM](https://user-images.githubusercontent.com/332167/69472157-696a9880-0d5b-11ea-9bd6-188f14320845.png)

after:
![Screen Shot 2019-11-22 at 7 04 33 PM](https://user-images.githubusercontent.com/332167/69472172-9c149100-0d5b-11ea-8e24-ba25a5bc0637.png)

Notes:
1) I left `form-group` in a className prop because that is a global style from bootstrap
2) I removed `login-form__submit` and `login-form__cancel` from className props because those aren't defined in any of the css files
3) My editor is set to remove trailing whitespace automatically on saves, hence the change on line 92 of web-monitoring-ui.jsx. If this is an unwelcome change to that file, just let me know!