### PR TITLE
Upgrade Node.js from v10 to v12.13.1 (newest LTS)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10.15.3
+      - image: circleci/node:12.13.1
     steps:
       - checkout
       - restore_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Baseline image for development/test/build ###
 # We require a lot of extras for building (Python, GCC) because of Node-Zopfli.
-FROM node:10.15.3 as dev
+FROM node:12.13.1 as dev
 LABEL maintainer="enviroDGI@gmail.com"
 
 RUN mkdir -p /app
@@ -30,7 +30,7 @@ RUN npm run build-production
 ### Release Image ###
 # It might feel ridiculous to build up all the same things again, but the
 # resulting image is less than half the size!
-FROM node:10.15.3-slim as release
+FROM node:12.13.1-slim as release
 LABEL maintainer="enviroDGI@gmail.com"
 
 # apt-get in this base image does not have dumb-init

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ It’s a React.js-based browser application with a Node.js backend with the foll
 
 ## Installation
 
-1. Install Node v10.15.3
-    - We recommend [installing Node Version Manager][nvm-install], then: `nvm install 10.15.3`
+1. Install Node v12.13.1
+    - We recommend [installing Node Version Manager][nvm-install], then: `nvm install 12.13.1`
     - If you are using Windows, check out [Nodenv][nodenv] or any of [these alternatives][nvm-alternatives].
 
 2. Install node dependencies with `npm`

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "author": "",
   "license": "GPL-3.0",
   "engines": {
-    "node": "10.15.3"
+    "node": "12.13.1"
   },
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
Node v12 is now the current LTS release, so this updates to it. This doesn’t have much impact on the client side code, but has some improvements (speed, stack traces) that are nice for the little bit of server-side stuff we have and for builds.

Fixes #426.