### PR TITLE
Test cleanup: PageList tests and fix `test-watch` running out of file handles

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
     },
     "setupFilesAfterEnv": [
       "<rootDir>src/test-setup.js"
+    ],
+    "roots": [
+      "<rootDir>/src",
+      "<rootDir>/server"
     ]
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -64,12 +64,15 @@
       "\\.css$": "<rootDir>/src/__mocks__/identity-object.js"
     },
     "setupFilesAfterEnv": [
-      "<rootDir>src/test-setup.js"
+      "<rootDir>/src/test-setup.js"
     ],
     "roots": [
       "<rootDir>/src",
       "<rootDir>/server"
-    ]
+    ],
+    "transform": {
+      "^.+\\.[t|j]sx?$": ["babel-jest", {"root": "."}]
+    }
   },
   "author": "",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -66,13 +66,10 @@
     "setupFilesAfterEnv": [
       "<rootDir>/src/test-setup.js"
     ],
-    "roots": [
-      "<rootDir>/src",
-      "<rootDir>/server"
-    ],
-    "transform": {
-      "^.+\\.[t|j]sx?$": ["babel-jest", {"root": "."}]
-    }
+    "watchPathIgnorePatterns": [
+      "<rootDir>/node_modules/",
+      "<rootDir>/\\..+/"
+    ]
   },
   "author": "",
   "license": "GPL-3.0",

--- a/src/components/__tests__/page-list.test.jsx
+++ b/src/components/__tests__/page-list.test.jsx
@@ -25,9 +25,7 @@ describe('page-list', () => {
 
   it('shows only sites from tags', () => {
     const pageList = shallow(
-      <PageList
-        pages={simplePages}
-      />
+      <PageList pages={simplePages} />
     );
     expect(pageList.find('tbody tr').first().childAt(1).text())
       .toBe('NOAA - ncei.noaa.gov, EPA - www3.epa.gov');
@@ -40,12 +38,17 @@ describe('page-list', () => {
     expect(pageList.find(SearchBar).length).toBe(1);
   });
 
-  it('displays Loading component when searching', () => {
+  it('displays Loading component when there are no pages', () => {
     const pageList = shallow(
-      <PageList 
-        pages={null} 
-      />
+      <PageList />
     );
     expect(pageList.find(Loading).length).toBe(1);
+  });
+
+  it('does not display Loading component when there are pages', () => {
+    const pageList = shallow(
+      <PageList pages={simplePages} />
+    );
+    expect(pageList.find(Loading).length).toBe(0);
   });
 });


### PR DESCRIPTION
This includes a few minor test fixes:

- Tiny syntax/language tweak in PageList tests.
- Adds a test for the case where we should *not* see the loading indicator.
- `npm run test-watch` has been broken for me for a little while, and I think someone else mentioned this at one of the Code4SF hack nights. This should fix it going nuts and trying to watch a bazillion files.