### PR TITLE
Ensure whitespace around assignment operators

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,7 @@
     "semi": [
       "error",
       "always"
-    ]
+    ],
+    "space-infix-ops": ["error"]
   }
 }

--- a/src/components/__tests__/login-form-test.jsx
+++ b/src/components/__tests__/login-form-test.jsx
@@ -6,7 +6,7 @@ import LoginPanel from '../login-form/login-form';
 import WebMonitoringDb from '../../services/web-monitoring-db';
 
 describe('login-form', () => {
-  const getMockedApi = (overrides={}) => Object.assign(
+  const getMockedApi = (overrides = {}) => Object.assign(
     Object.create(WebMonitoringDb.prototype),
     overrides
   );

--- a/src/services/web-monitoring-api.js
+++ b/src/services/web-monitoring-api.js
@@ -51,7 +51,7 @@ export default class WebMonitoringApi {
     );
   }
 
-  _postChange (page, fromVersion, toVersion, annotation, url, description='save a change') {
+  _postChange (page, fromVersion, toVersion, annotation, url, description = 'save a change') {
     if (!this.dbApi.userData) {
       return Promise.reject(
         new Error(`You must be logged in to ${description}.`));


### PR DESCRIPTION
We keep bugging people about having whitespace around the equals sign for default argument values (e.g. `function (argumentName='value')` should be `function (argumentName = 'value')`), so this adds that rule via ESLint.