### PR TITLE
Use new `version.media_type` API field

### DIFF
--- a/src/__mocks__/simple-page.json
+++ b/src/__mocks__/simple-page.json
@@ -11,6 +11,9 @@
       "capture_time": "2018-02-01T04:37:15.000Z",
       "uri": "https://edgi-versionista-archive.s3.amazonaws.com/versionista2/74303-6222064/version-14470996.html",
       "version_hash": "15e3e7f86e3f72acd360668b22250b9981f7b3d5f777b3d972557f00cd21153f",
+      "media_type": "text/html",
+      "media_type_parameters": "charset=UTF-8",
+      "content_length": 31190,
       "source_type": "versionista",
       "source_metadata": {
         "url": "https://versionista.com/74303/6222064/14470996/",
@@ -50,6 +53,9 @@
       "capture_time": "2017-01-17T13:46:48.000Z",
       "uri": "https://edgi-versionista-archive.s3.amazonaws.com/versionista2/74303-6222064/version-9437401.html",
       "version_hash": "03942355429ebd4bf526199777879fdf069a23ec040a9517b556df8aa4d1a8d3",
+      "media_type": null,
+      "media_type_parameters": null,
+      "content_length": 31190,
       "source_type": "versionista",
       "source_metadata": {
         "url": "https://versionista.com/74303/6222064/9437401/",

--- a/src/__mocks__/simple-pages.json
+++ b/src/__mocks__/simple-pages.json
@@ -11,6 +11,9 @@
       "capture_time": "2018-03-04T16:33:33.000Z",
       "uri": "https://edgi-versionista-archive.s3.amazonaws.com/versionista2/74300-6219628/version-14835175.xml",
       "version_hash": "e6f32277c22dece27b719310a65c46f4e21eb3f1c3d13fe82d9cead78bc52186",
+      "media_type": "application/xml",
+      "media_type_parameters": "charset=utf-8",
+      "content_length": 8013,
       "source_type": "versionista",
       "source_metadata": {
         "url": "https://versionista.com/74300/6219628/14835175/",
@@ -86,6 +89,9 @@
       "capture_time": "2017-06-19T11:59:22.000Z",
       "uri": "https://edgi-versionista-archive.s3.amazonaws.com/versionista1/71555-6026676/version-11816086.html",
       "version_hash": "10c2283c9e8768980bcc343e7b76a6f51b4dae3632a7f35cd037b8add71b9d0e",
+      "media_type": null,
+      "media_type_parameters": null,
+      "content_length": 31190,
       "source_type": "versionista",
       "source_metadata": {
         "url": "https://versionista.com/71555/6026676/11816086/",

--- a/src/components/__tests__/change-view.test.jsx
+++ b/src/components/__tests__/change-view.test.jsx
@@ -54,8 +54,8 @@ describe('change-view', () => {
         const changeView = shallow(
           <ChangeView
             page={simplePage}
-            from={{content_type: 'text/html'}}
-            to={{content_type: 'text/html'}}
+            from={{media_type: 'text/html'}}
+            to={{media_type: 'text/html'}}
             user={{email: 'me'}}
           />,
           {context: {api: mockApi}}
@@ -72,8 +72,8 @@ describe('change-view', () => {
           const changeView = shallow(
             <ChangeView
               page={simplePage}
-              from={{content_type: 'text/html'}}
-              to={{content_type: 'text/html'}}
+              from={{media_type: 'text/html'}}
+              to={{media_type: 'text/html'}}
               user={{email: 'me'}}
             />,
             {context: {api: mockApi}}
@@ -92,8 +92,8 @@ describe('change-view', () => {
           const changeView = shallow(
             <ChangeView
               page={simplePage}
-              from={{content_type: mediaType}}
-              to={{content_type: mediaType}}
+              from={{media_type: mediaType}}
+              to={{media_type: mediaType}}
               user={{email: 'me'}}
             />,
             {context: {api: mockApi}}
@@ -109,8 +109,8 @@ describe('change-view', () => {
         const changeView = shallow(
           <ChangeView
             page={simplePage}
-            from={{content_type: 'text/html'}}
-            to={{content_type: 'text/html'}}
+            from={{media_type: 'text/html'}}
+            to={{media_type: 'text/html'}}
             user={{email: 'me'}}
           />,
           {context: {api: mockApi}}
@@ -126,8 +126,8 @@ describe('change-view', () => {
         const changeView = shallow(
           <ChangeView
             page={simplePage}
-            from={{content_type: mediaType}}
-            to={{content_type: mediaType}}
+            from={{media_type: mediaType}}
+            to={{media_type: mediaType}}
             user={{email: 'me'}}
           />,
           {context: {api: mockApi}}
@@ -148,16 +148,16 @@ describe('change-view', () => {
       const changeView = shallow(
         <ChangeView
           page={simplePage}
-          from={{content_type: oldMediaType}}
-          to={{content_type: oldMediaType}}
+          from={{media_type: oldMediaType}}
+          to={{media_type: oldMediaType}}
           user={{email: 'me'}}
         />,
         {context: {api: mockApi}}
       );
 
       changeView.setProps({
-        from: {content_type: newMediaType},
-        to: {content_type: newMediaType},
+        from: {media_type: newMediaType},
+        to: {media_type: newMediaType},
       });
 
       expect(changeView.state().diffType).toBe(diffType);
@@ -176,16 +176,16 @@ describe('change-view', () => {
           const changeView = shallow(
             <ChangeView
               page={simplePage}
-              from={{content_type: oldMediaType}}
-              to={{content_type: oldMediaType}}
+              from={{media_type: oldMediaType}}
+              to={{media_type: oldMediaType}}
               user={{email: 'me'}}
             />,
             {context: {api: mockApi}}
           );
 
           changeView.setProps({
-            from: {content_type: newMediaType},
-            to: {content_type: newMediaType},
+            from: {media_type: newMediaType},
+            to: {media_type: newMediaType},
           });
 
           expect(changeView.state().diffType).toBe(storedDiffType);
@@ -201,16 +201,16 @@ describe('change-view', () => {
           const changeView = shallow(
             <ChangeView
               page={simplePage}
-              from={{content_type: oldMediaType}}
-              to={{content_type: oldMediaType}}
+              from={{media_type: oldMediaType}}
+              to={{media_type: oldMediaType}}
               user={{email: 'me'}}
             />,
             {context: {api: mockApi}}
           );
 
           changeView.setProps({
-            from: {content_type: newMediaType},
-            to: {content_type: newMediaType},
+            from: {media_type: newMediaType},
+            to: {media_type: newMediaType},
           });
 
           expect(changeView.state().diffType).toBe(defaultDiffType);
@@ -226,16 +226,16 @@ describe('change-view', () => {
           const changeView = shallow(
             <ChangeView
               page={simplePage}
-              from={{content_type: oldMediaType}}
-              to={{content_type: oldMediaType}}
+              from={{media_type: oldMediaType}}
+              to={{media_type: oldMediaType}}
               user={{email: 'me'}}
             />,
             {context: {api: mockApi}}
           );
 
           changeView.setProps({
-            from: {content_type: newMediaType},
-            to: {content_type: newMediaType},
+            from: {media_type: newMediaType},
+            to: {media_type: newMediaType},
           });
 
           expect(changeView.state().diffType).toBe(diffTypesFor(newMediaType)[0].value);
@@ -250,16 +250,16 @@ describe('change-view', () => {
       const changeView = shallow(
         <ChangeView
           page={simplePage}
-          from={{content_type: oldMediaType}}
-          to={{content_type: oldMediaType}}
+          from={{media_type: oldMediaType}}
+          to={{media_type: oldMediaType}}
           user={{email: 'me'}}
         />,
         {context: {api: mockApi}}
       );
 
       changeView.setProps({
-        from: {content_type: newMediaType},
-        to: {content_type: newMediaType},
+        from: {media_type: newMediaType},
+        to: {media_type: newMediaType},
       });
 
       expect(changeView.state().diffType).toBe(defaultDiffType);
@@ -272,16 +272,16 @@ describe('change-view', () => {
       const changeView = shallow(
         <ChangeView
           page={simplePage}
-          from={{content_type: oldMediaType}}
-          to={{content_type: oldMediaType}}
+          from={{media_type: oldMediaType}}
+          to={{media_type: oldMediaType}}
           user={{email: 'me'}}
         />,
         {context: {api: mockApi}}
       );
 
       changeView.setProps({
-        from: {content_type: newMediaType},
-        to: {content_type: newMediaType},
+        from: {media_type: newMediaType},
+        to: {media_type: newMediaType},
       });
 
       expect(changeView.state().diffType).toBe(diffTypesFor(newMediaType)[0].value);
@@ -293,8 +293,8 @@ describe('change-view', () => {
       const changeView = shallow(
         <ChangeView
           page={simplePage}
-          from={{content_type: 'text/html'}}
-          to={{content_type: 'text/html'}}
+          from={{media_type: 'text/html'}}
+          to={{media_type: 'text/html'}}
           user={{email: 'me'}}
         />,
         {context: {api: mockApi}}
@@ -316,8 +316,8 @@ describe('change-view', () => {
       const changeView = shallow(
         <ChangeView
           page={simplePage}
-          from={{content_type: 'text/html'}}
-          to={{content_type: 'text/html'}}
+          from={{media_type: 'text/html'}}
+          to={{media_type: 'text/html'}}
           user={{email: 'me'}}
         />,
         {context: {api: mockApi}}

--- a/src/components/change-view/change-view.jsx
+++ b/src/components/change-view/change-view.jsx
@@ -390,12 +390,8 @@ function relevantDiffTypes (versionA, versionB, page) {
 const extensionExpression = /^([^:]+:\/\/)?.*\/[^/]*(\.[^/]+)$/;
 
 function mediaTypeForVersion (version, page) {
-  const contentType = version.content_type
-    || version.source_metadata.content_type
-    || version.source_metadata.mime_type;
-
-  if (contentType) {
-    return parseMediaType(contentType);
+  if (version.media_type) {
+    return parseMediaType(version.media_type);
   }
 
   const extensionType = mediaTypeForUrl(version.uri)


### PR DESCRIPTION
As of edgi-govdata-archiving/web-monitoring-db#669, the API now includes media type information, so we don't need to work so hard to figure it out.

The tests specified “versions” that had fields (`content_type`) that never actually existed (somehow I missed that in the review 🙁), so I’ve updated those, too.