### PR TITLE
Prevent opening up intra-page links in separate tab/window in diff view closes #494

### DIFF
--- a/src/scripts/__tests__/html-transforms.test.js
+++ b/src/scripts/__tests__/html-transforms.test.js
@@ -61,7 +61,7 @@ describe('HtmlTransforms module', () => {
     expect(document.querySelector('.wm-diff-other')).toBeInstanceOf(Element);
   });
 
-  test('addTargetBlank adds a target attribute of "_blank" to only <a> tags', () => {
+  test('addTargetBlank adds a target attribute of "_blank" to only <a> tags, excluding intra-page links', () => {
     let document = parser.parseFromString(`<!doctype html>
       <html>
         <head>
@@ -77,6 +77,8 @@ describe('HtmlTransforms module', () => {
             body { background: purple; }
           </style>
           <a href='google.com' id='goo'>Goo test</a>
+          <a href='#main' id='intra1'>Inta test for #</a>
+          <a href='javascript:;' id='intra2'>Intra test for javascript</a>
           <h1 style='color: orange;' id='orange'>Hello</h1>
         </body>
       </html>
@@ -85,5 +87,7 @@ describe('HtmlTransforms module', () => {
     document = addTargetBlank(document);
     expect(document.getElementById('goo').target).toEqual('_blank');
     expect(document.getElementById('orange').target).toBeFalsy();
+    expect(document.getElementById('intra1').target).toBeFalsy();
+    expect(document.getElementById('intra2').target).toBeFalsy();
   });
 });

--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -50,7 +50,7 @@ export function removeStyleAndScript (document) {
 
 /**
  * Prevents navigation from within a diff by forcing links to open in a new
- * tab when clicked. This helps ensure we don’t get in a state where one side
+ * tab when clicked (excluding intra-page links). This helps ensure we don’t get in a state where one side
  * of a side-by-side diff has been navigated and viewer does not realize they
  * are no longer actually looking at a *diff*.
  *
@@ -62,8 +62,14 @@ export function removeStyleAndScript (document) {
 export function addTargetBlank (document) {
   // Add target="_blank" to all <a>tags
   document.querySelectorAll('a').forEach(node => {
-    node.setAttribute('target', '_blank');
+    // set href to empty string in case attribute is null
+    const href = node.getAttribute('href') || '';
+
+    if (href.charAt(0) !== '#' && href.indexOf('javascript:') !== 0) {
+      node.setAttribute('target', '_blank');
+    }
   });
+
   return document;
 }
 

--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -50,7 +50,8 @@ export function removeStyleAndScript (document) {
 
 /**
  * Prevents navigation from within a diff by forcing links to open in a new
- * tab when clicked (excluding intra-page links). This helps ensure we don’t get in a state where one side
+ * tab when clicked (excluding intra-page links).
+ * This helps ensure we don’t get in a state where one side
  * of a side-by-side diff has been navigated and viewer does not realize they
  * are no longer actually looking at a *diff*.
  *
@@ -65,7 +66,7 @@ export function addTargetBlank (document) {
     // set href to empty string in case attribute is null
     const href = node.getAttribute('href') || '';
 
-    if (href.charAt(0) !== '#' && href.indexOf('javascript:') !== 0) {
+    if (!href.startsWith('#') && !href.startsWith('javascript:')) {
       node.setAttribute('target', '_blank');
     }
   });


### PR DESCRIPTION
I wasn't able to access the page mentioned in the issue (https://monitoring.envirodatagov.org/page/c7a491b7-b296-4bdf-965e-372a87a7ac05/6f12e08a-a7f7-4ed1-8775-8c3791614fba..1fdefab4-bf6e-4829-892a-32c35466ae3d) but seems to be working as expected when I test locally.