### PR TITLE
Add BundeWatch for keeping JS size in check

### DIFF
--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -1,0 +1,28 @@
+module.exports = {
+  "files": [
+    // Catch-all in case we add other JS files
+    {
+      "path": "dist/*.js",
+      "maxSize": "200kB"
+    },
+
+    // Main bundles
+    {
+      "path": "dist/bundle.js",
+      "maxSize": "750kB",
+      "compression": "none"
+    },
+    {
+      "path": "dist/bundle.js.gz",
+      "maxSize": "250kB",
+      // This file is pre-compressed, so bundlewatch needs to be told not to
+      // compress before comparing.
+      "compression": "none"
+    }
+  ],
+
+  "ci": {
+      // NOTE: this will soon change to "main"
+      "trackBranches": ["master"]
+  }
+};

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-2-{{ checksum "package-lock.json" }}
+          keys:
+            - dependency-cache-2-{{ checksum "package-lock.json" }}
+            - dependency-cache-2-
       - run:
           name: Dependencies
           command: npm ci
@@ -17,6 +19,9 @@ jobs:
       - run:
           name: Build
           command: npm run build-production
+      - run:
+          name: Check Bundle Size
+          command: node_modules/.bin/bundlewatch --config .bundlewatch.config.js
       - run:
           name: Run linter
           command: npm run lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,9 @@
-version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/node:12.13.1
+version: 2.1
+
+commands:
+  setup_npm:
+    description: "Set up NPM dependencies"
     steps:
-      - checkout
       - restore_cache:
           keys:
             - dependency-cache-2-{{ checksum "package-lock.json" }}
@@ -16,14 +15,29 @@ jobs:
           key: dependency-cache-2-{{ checksum "package-lock.json" }}
           paths:
             - ./node_modules
+
+jobs:
+  build:
+    docker:
+      - image: cimg/node:12.18.3
+    steps:
+      - checkout
+      - setup_npm
       - run:
           name: Build
           command: npm run build-production
       - run:
           name: Check Bundle Size
-          command: node_modules/.bin/bundlewatch --config .bundlewatch.config.js
+          command: npm run bundlewatch
+
+  test:
+    docker:
+      - image: cimg/node:12.18.3
+    steps:
+      - checkout
+      - setup_npm
       - run:
-          name: Run linter
+          name: Lint Code
           command: npm run lint
       - run:
           name: Test
@@ -43,10 +57,13 @@ jobs:
           docker push envirodgi/ui:latest
 
 workflows:
-  version: 2
   build:
     jobs:
       - build:
+          filters:
+            branches:
+              ignore: release
+      - test:
           filters:
             branches:
               ignore: release

--- a/package-lock.json
+++ b/package-lock.json
@@ -3796,6 +3796,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -5109,6 +5118,82 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "bundlewatch": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/bundlewatch/-/bundlewatch-0.2.7.tgz",
+      "integrity": "sha512-tTf6TZHowf2kqHMv9nk7ORDdyU8d4OCF5qjkm8jeZfY9hsOdoyvDq3xtPSw+I8eQJJhkdUvcIMp4Cd3GkUAsrA==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.19.0",
+        "bytes": "^3.0.0",
+        "chalk": "^4.0.0",
+        "ci-env": "^1.14.0",
+        "commander": "^5.0.0",
+        "glob": "^7.1.2",
+        "gzip-size": "^5.1.1",
+        "jsonpack": "^1.1.5",
+        "lodash.merge": "^4.6.1",
+        "read-pkg-up": "^7.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -5337,6 +5422,12 @@
       "requires": {
         "tslib": "^1.9.0"
       }
+    },
+    "ci-env": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.16.0.tgz",
+      "integrity": "sha512-ucF9caQEX5wQlY449KZBIJPx91+kRg9tJ3tWSc4+KzrvC5KNiPm/3g1noP8VhdI3046+Vw3jLmKAD0fjCRJTmw==",
+      "dev": true
     },
     "ci-info": {
       "version": "2.0.0",
@@ -6386,6 +6477,12 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
     "duplexify": {
@@ -7665,6 +7762,26 @@
         "focus-trap": "^4.0.2"
       }
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -8569,6 +8686,16 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
           "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
         }
+      }
+    },
+    "gzip-size": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
+      "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
+      "dev": true,
+      "requires": {
+        "duplexer": "^0.1.1",
+        "pify": "^4.0.1"
       }
     },
     "har-schema": {
@@ -11284,6 +11411,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonpack": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/jsonpack/-/jsonpack-1.1.5.tgz",
+      "integrity": "sha1-1CsNz9kaxY7zEQ+W0sWZQEw9wnw=",
+      "dev": true
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -11473,6 +11606,12 @@
         "lodash.isarguments": "^3.0.0",
         "lodash.isarray": "^3.0.0"
       }
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "autoprefixer": "^9.8.6",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.1.0",
+    "bundlewatch": "^0.2.7",
     "compression-webpack-plugin": "^4.0.0",
     "css-loader": "^4.2.0",
     "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "scripts": {
     "build": "webpack",
     "build-production": "NODE_ENV=production webpack",
+    "bundlewatch": "bundlewatch --config .bundlewatch.config.js",
     "lint": "eslint --ignore-path .gitignore './**/*.{js,jsx}'",
     "start": "node server/app.js",
     "test": "jest --colors",


### PR DESCRIPTION
This is an alternative to the code I originally added in #490 for checking in on bundle sizes. It’s not a lot more code on our end, but it *is* a lot more complex overall, adding more dependencies and a third party service. On the other hand, it gets us much nicer output.

See this PR for an example of it passing:

<img width="838" alt="Screen Shot 2020-08-02 at 1 27 09 PM" src="https://user-images.githubusercontent.com/74178/89131725-e42bac00-d4c3-11ea-991d-7665d899edce.png">

See #578 for what it looks like when it’s failing:

<img width="840" alt="Screen Shot 2020-08-02 at 1 23 34 PM" src="https://user-images.githubusercontent.com/74178/89131671-71223580-d4c3-11ea-97ad-df4976b2b22a.png">

And the details link takes you to a nice summary and visualization of the results:

<img width="922" alt="Screen Shot 2020-08-02 at 1 23 53 PM" src="https://user-images.githubusercontent.com/74178/89131680-86975f80-d4c3-11ea-8316-1012fe78a01a.png">

Unfortunately it doesn’t fail if the bundle size increased by a given percentage (only an absolute size threshold), but it does tell you how much the bundle size changed by in the summary (you can see that on this PR), which is still pretty good. We could also always add custom code to fail if the size increases by too much. Probably not worthwhile, though.