### PR TITLE
HOTFIX: Revert css-loader to v3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5822,24 +5822,24 @@
       }
     },
     "css-loader": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-4.2.0.tgz",
-      "integrity": "sha512-ko7a9b0iFpWtk9eSI/C8IICvZeGtYnjxYjw45rJprokXj/+kBd/siX4vAIBq9Uij8Jubc4jL1EvSnTjCEwaHSw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
+      "integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^6.0.0",
+        "camelcase": "^5.3.1",
         "cssesc": "^3.0.0",
         "icss-utils": "^4.1.1",
-        "loader-utils": "^2.0.0",
+        "loader-utils": "^1.2.3",
         "normalize-path": "^3.0.0",
         "postcss": "^7.0.32",
         "postcss-modules-extract-imports": "^2.0.0",
-        "postcss-modules-local-by-default": "^3.0.3",
+        "postcss-modules-local-by-default": "^3.0.2",
         "postcss-modules-scope": "^2.2.0",
         "postcss-modules-values": "^3.0.0",
         "postcss-value-parser": "^4.1.0",
         "schema-utils": "^2.7.0",
-        "semver": "^7.3.2"
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "ajv": {
@@ -5852,32 +5852,6 @@
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
-          }
-        },
-        "camelcase": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
-          "dev": true
-        },
-        "json5": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
           }
         },
         "postcss": {
@@ -5944,9 +5918,9 @@
           }
         },
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.1.0",
     "compression-webpack-plugin": "^4.0.0",
-    "css-loader": "^4.2.0",
+    "css-loader": "^3.6.0",
     "dotenv": "^8.2.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",


### PR DESCRIPTION
Css-loader v4+ and babel-plugin-react-css-modules are not compatible with each other. Using them together relies on the fact that they happen to have similar methods for building identifier names for CSS rules, and that similarity disappeared in css-loader v4. Their *might* be a workaround for this by using functions instead of template strings for identifier names, but that requires a little more exploration. For now, we can solve this by reverting css-loader.