### PR TITLE
Remove non-english locales from Moment.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11532,6 +11532,12 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
+    },
     "lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
@@ -11900,6 +11906,15 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.0.tgz",
       "integrity": "sha512-vbrf6kJGpevOxmDRvCCvGuCSXvRj93264WcFzjm3Z3pV4lfjrXll8rvSP+EbmCte64udj1LkJMILxQnjXAQBzg==",
       "dev": true
+    },
+    "moment-locales-webpack-plugin": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz",
+      "integrity": "sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==",
+      "dev": true,
+      "requires": {
+        "lodash.difference": "^4.5.0"
+      }
     },
     "moo": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "husky": "^4.2.5",
     "jest": "^26.2.2",
     "moment": "^2.25.0",
+    "moment-locales-webpack-plugin": "^1.2.0",
     "node-fetch": "^2.2.0",
     "postcss-loader": "^3.0.0",
     "prop-types": "^15.6.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const autoprefixer = require('autoprefixer');
 const CompressionPlugin = require('compression-webpack-plugin');
+const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const path = require('path');
 const zopfli = require('@gfx/zopfli');
 
@@ -139,7 +140,10 @@ module.exports = {
       }
     ],
   },
-  plugins: [],
+  plugins: [
+    // Strip locales from Moment.js (we only use English)
+    new MomentLocalesPlugin()
+  ],
 };
 
 // Production-specific additions


### PR DESCRIPTION
Our bundle size has grown pretty large, and a significant chunk of it used to be localization data for Moment.js. Since we only show the site in English, that's a bit of a waste. This removes non-English locales from our built bundle.

NOTE: Technically the extra locales aren’t currently being included and this PR makes no difference to the bundle size, but only because of a bug with Moment.js (see https://github.com/moment/moment/issues/5489). The latest version of Moment fixes the issue, but pumps our size back up (see #556). This should prevent that.

**This is a replacement for part of #490.** Another part (adding bundle analyzer) I’ll do separately to keep things clean. And the last part (automatically checking for size increases) is already done in #579.

