### PR TITLE
Update staging API URL throughout codebase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,10 @@
 # If you are developing the API locally, set this to the URL of your local web-monitoring-db instance
 # EDGI's staging database (good for testing!) is:
-#     https://api-staging.monitoring.envirodatagov.org
+#     https://api.monitoring-staging.envirodatagov.org
 # And you can use the public account's login credentials on it:
 #     Username: public.access@envirodatagov.org
 #     Password: PUBLIC_ACCESS
-WEB_MONITORING_DB_URL=https://api-staging.monitoring.envirodatagov.org
+WEB_MONITORING_DB_URL=https://api.monitoring-staging.envirodatagov.org
 
 # Redirect all HTTP requests to https (you probably want this off in development)
 # FORCE_SSL=true

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This component works with [web-monitoring-db](https://github.com/edgi-govdata-ar
 It’s a React.js-based browser application with a Node.js backend with the following capabilities:
 * Consume subset of data from web-monitoring-db as proof of concept, read/write annotations
     * [DEMO](https://monitoring-staging.envirodatagov.org)
-    * LIST VIEW shows first page of records from [web-monitor-db](https://api-staging.monitoring.envirdatagov.org/api/v0/pages) JSON endpoint
+    * LIST VIEW shows first page of records from [web-monitor-db](https://api.monitoring-staging.envirdatagov.org/api/v0/pages) JSON endpoint
     * PAGE VIEW shows basic info about the latest version of that page: site, URLs and links to Wayback Machine calendar view and page versions
         * updates annotations
 

--- a/server/configuration.js
+++ b/server/configuration.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const defaultValues = {
-  WEB_MONITORING_DB_URL: 'https://api-staging.monitoring.envirodatagov.org'
+  WEB_MONITORING_DB_URL: 'https://api.monitoring-staging.envirodatagov.org'
 };
 
 const clientFields = [

--- a/src/components/__tests__/environment-banner.test.jsx
+++ b/src/components/__tests__/environment-banner.test.jsx
@@ -13,7 +13,16 @@ describe('EnvironmentBanner', () => {
     expect(banner.children().exists()).toBe(false);
   });
 
-  it('renders a message indicating the environment in staging', () => {
+  it('displays the correct environment for staging', () => {
+    const banner = mount(<EnvironmentBanner
+      apiUrl="https://api.monitoring-staging.envirodatagov.org"
+    />);
+
+    expect(banner.children().exists()).toBe(true);
+    expect(banner.text()).toMatch(/\bstaging\b/);
+  });
+
+  it('displays the correct environment for the deprecated staging URL', () => {
     const banner = mount(<EnvironmentBanner
       apiUrl="https://api-staging.monitoring.envirodatagov.org"
     />);

--- a/src/components/environment-banner/environment-banner.jsx
+++ b/src/components/environment-banner/environment-banner.jsx
@@ -25,7 +25,8 @@ export default class EnvironmentBanner extends React.Component {
   componentDidMount () {
     // This is not a good method, but a proof of concept.
     // TODO: see about querying the data via this.context.api
-    const environment = (this.props.apiUrl.match(/api-([^.]+)/i) || [])[1];
+    const urlMatch = this.props.apiUrl.match(/(?:api|monitoring)-([^.]+)/i);
+    const environment = urlMatch ? urlMatch[1] : 'production';
     if (environment) {
       this.setState({ apiEnvironment: environment });
     }

--- a/src/services/web-monitoring-db.js
+++ b/src/services/web-monitoring-db.js
@@ -1,5 +1,5 @@
 import { formatDateRange } from '../scripts/db-helpers';
-const defaultApiUrl = 'https://api-staging.monitoring.envirodatagov.org/';
+const defaultApiUrl = 'https://api.monitoring-staging.envirodatagov.org/';
 const storageLocation = 'WebMonitoringDb.token';
 
 /**


### PR DESCRIPTION
A while back, we updated the staging API URL to `https://api.monitoring-staging.envirodatagov.org`, so everything about staging exists under `monitoring-staging`. The old URL is also supported, but the new one is preferred. This updates all the places we reference it here.