### PR TITLE
Flag versions that were errors in version dropdown

### DIFF
--- a/src/components/select-version.jsx
+++ b/src/components/select-version.jsx
@@ -23,7 +23,9 @@ export default class SelectVersion extends React.PureComponent {
     const options = versions.map(version => {
       return (
         <option key={version.uuid} value={version.uuid}>
-          {dateFormatter.format(version.capture_time)}{sourceLabel(version)}
+          {statusLabel(version)}
+          {dateFormatter.format(version.capture_time)}
+          {sourceLabel(version)}
         </option>
       );
     });
@@ -42,5 +44,18 @@ function sourceLabel (version) {
     case 'versionista':      return ' (Versionista)';
     case 'internet_archive': return ' (Wayback)';
     default:                 return '';
+  }
+}
+
+function statusLabel (version) {
+  const status = version.status || 200;
+  if (status >= 400) {
+    return `✗ (${version.status} Error) `;
+  }
+  else if (version.content_length === 0) {
+    return '✗ (No Content) ';
+  }
+  else {
+    return '';
   }
 }


### PR DESCRIPTION
In the dropdown for selecting versions of a page to compare, we now show an "x" and the status code next to versions that were errors. This is helpful when trying to skip over intermittent errors or determining how long a page has been erroring for.

Example snapshots:

<img width="511" alt="Screen Shot 2020-11-18 at 10 09 50 AM" src="https://user-images.githubusercontent.com/74178/100168838-dfc23f00-2e76-11eb-9531-5a8336dd8077.png">

<img width="518" alt="Screen Shot 2020-11-18 at 10 01 04 AM" src="https://user-images.githubusercontent.com/74178/100168862-ee105b00-2e76-11eb-8594-88b7794e9fca.png">