### PR TITLE
Remove and flag client-side redirects in diffs

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "bundlewatch": "bundlewatch --config .bundlewatch.config.js",
     "lint": "eslint --ignore-path .gitignore './**/*.{js,jsx}'",
     "start": "node server/app.js",
-    "test": "jest --colors",
+    "test": "jest --colors --verbose",
     "test-watch": "jest --watch"
   },
   "husky": {

--- a/src/components/side-by-side-rendered-diff.jsx
+++ b/src/components/side-by-side-rendered-diff.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   removeStyleAndScript,
+  removeClientRedirect,
   loadSubresourcesFromWayback,
   compose,
   addTargetBlank
@@ -26,7 +27,11 @@ import SandboxedHtml from './sandboxed-html';
  */
 export default class SideBySideRenderedDiff extends React.Component {
   render () {
-    const baseTransform = compose(this.props.removeFormatting && removeStyleAndScript, addTargetBlank);
+    const baseTransform = compose(
+      this.props.removeFormatting && removeStyleAndScript,
+      addTargetBlank,
+      removeClientRedirect
+    );
     let transformA = baseTransform;
     let transformB = baseTransform;
     if (this.props.useWaybackResources) {

--- a/src/scripts/__tests__/html-transforms.test.js
+++ b/src/scripts/__tests__/html-transforms.test.js
@@ -1,6 +1,10 @@
 /* eslint-env jest */
 
-import { removeStyleAndScript, addTargetBlank } from '../html-transforms';
+import {
+  removeClientRedirect,
+  removeStyleAndScript,
+  addTargetBlank
+} from '../html-transforms';
 
 
 describe('HtmlTransforms module', () => {
@@ -59,6 +63,50 @@ describe('HtmlTransforms module', () => {
     expect(document.getElementById('wm-diff-script')).toBeInstanceOf(Element);
     expect(document.querySelector('.wm-diff-other')).toBeInstanceOf(Element);
     expect(document.querySelector('.wm-diff-other')).toBeInstanceOf(Element);
+  });
+
+  describe('removeClientRedirect', () => {
+
+    test('removes meta refresh elements', () => {
+      let document = parser.parseFromString(`<!doctype html>
+        <html>
+          <head>
+            <meta charset="utf-8">
+            <title>Test!</title>
+            <meta http-equiv="refresh" content="0; url=https://www.epa.gov/pi" />
+            <meta name="description" content="THIS IS A TEST" />
+          </head>
+          <body>
+            <h1 style="color: orange;">Hello</h1>
+          </body>
+        </html>
+      `, 'text/html');
+
+      document = removeClientRedirect(document);
+      const metas = document.querySelectorAll('meta');
+      expect(metas).toHaveLength(2);
+      expect(metas[0].getAttribute('charset')).toEqual('utf-8');
+      expect(metas[1]).toHaveProperty('name', 'description');
+    });
+
+    test('displays a banner when meta refresh elements are present', () => {
+      let document = parser.parseFromString(`<!doctype html>
+        <html>
+          <head>
+            <meta http-equiv="refresh" content="0; url=https://www.epa.gov/pi" />
+          </head>
+          <body>
+            <h1 style="color: orange;">Hello</h1>
+          </body>
+        </html>
+      `, 'text/html');
+
+      document = removeClientRedirect(document);
+      const banner = document.querySelector('.wm-redirect-banner');
+      expect(banner).toBeInstanceOf(HTMLElement);
+      expect(banner.innerHTML).toContain('redirect');
+    });
+
   });
 
   test('addTargetBlank adds a target attribute of "_blank" to only <a> tags', () => {


### PR DESCRIPTION
When viewing a diff of a page that has client-side redirects, the experience can be pretty confusing. Because we are diffing the page's HTML, you never see the actual comparison. The comparison loads, but then immediately redirects somewhere else (often a live webpage instead of an archived copy). The page *looks* fine, but things aren't highlighted like you might expect.

This change finds client-side redirects using the `<meta>` tag (and could handle other types of redirects in the future). It then removes them and adds a banner to the top of the page describing the redirect. This way, a user sees what was actually compared/diffed, and also gets notified about the redirect and has the option to investigate it.

Partially covers #201.

This looks like:

<img width="1392" alt="Screen Shot 2020-11-24 at 4 44 02 PM" src="https://user-images.githubusercontent.com/74178/100170724-29ad2400-2e7b-11eb-815b-71e4458b7ac8.png">

(Most pages with client-side redirects, like this one, have no content. When there is content, the banner should get placed at the top.)
