### PR TITLE
Redirect to the correct URL for merged pages

### DIFF
--- a/src/components/page-details/page-details.jsx
+++ b/src/components/page-details/page-details.jsx
@@ -96,6 +96,12 @@ export default class PageDetails extends React.Component {
       return (<Loading />);
     }
 
+    if (this.state.page.merged_into) {
+      const targetId = this.state.page.merged_into;
+      const changeId = this.props.match.params.change || '';
+      return <Redirect to={`/page/${targetId}/${changeId}`} />;
+    }
+
     // TODO: this HTML should probably be broken up a bit
     return (
       <div styleName="baseStyles.main pageStyles.page-details-main">
@@ -249,6 +255,11 @@ export default class PageDetails extends React.Component {
      */
     Promise.resolve(fromList || this.context.api.getPage(pageId))
       .then(page => {
+        // If we redirected to a different page ID, store a special object so
+        // we can redirect on render.
+        if (page.uuid !== pageId) {
+          this.setState({ page: { uuid: pageId, merged_into: page.uuid } });
+        }
         this._loadVersions(page, cutoffDate, '')
           .then(versions => {
             page.versions = versions;


### PR DESCRIPTION
When loading page data on the page details view, we might get a redirect from the API because a page was merged. This reflects that redirect in the UI's URL, ensuring that old change links redirect to the same view for the new, merged page.

(Merged pages are new in edgi-govdata-archiving/web-monitoring-db#793.)