### PR TITLE
Fix Docker Builds (downloading dumb-init)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,23 +43,50 @@ jobs:
           name: Test
           command: npm test
 
-  publish_docker:
+  build_docker:
     machine: true
     steps:
       - checkout
-      - run: |
-          docker login -u $DOCKER_USER -p $DOCKER_PASS
-      - run: |
-          docker build -t envirodgi/ui:$CIRCLE_SHA1 .
-          docker build -t envirodgi/ui:latest .
-      - run: |
-          docker push envirodgi/ui:$CIRCLE_SHA1
-          docker push envirodgi/ui:latest
+      - run:
+          name: Build Image
+          command: |
+            docker build -t envirodgi/ui:$CIRCLE_SHA1 .
+      - run:
+          name: Save Image
+          command: |
+            mkdir /tmp/workspace
+            docker save --output /tmp/workspace/docker-image envirodgi/ui:$CIRCLE_SHA1
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - docker-image
+
+  publish_docker:
+    machine: true
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Load Built Docker Image
+          command: docker load --input /tmp/workspace/docker-image
+      - run:
+          name: Docker Login
+          command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run:
+          name: Publish Images
+          command: |
+            docker image tag envirodgi/ui:${CIRCLE_SHA1} envirodgi/ui:latest
+            docker push envirodgi/web-monitoring-diff:${CIRCLE_SHA1}
+            docker push envirodgi/web-monitoring-diff:latest
 
 workflows:
   build:
     jobs:
       - build:
+          filters:
+            branches:
+              ignore: release
+      - build_docker:
           filters:
             branches:
               ignore: release
@@ -75,6 +102,12 @@ workflows:
             branches:
               only:
                 - release
+      - build_docker:
+          filters:
+            branches:
+              only:
+                - release
       - publish_docker:
           requires:
             - build
+            - build_docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,7 @@ RUN npm run build-production
 FROM node:14.16.0-slim as release
 LABEL maintainer="enviroDGI@gmail.com"
 
-# apt-get in this base image does not have dumb-init
-RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64
-RUN chmod +x /usr/local/bin/dumb-init
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
When I upgraded to Node v14, I didn’t realize the new base image for Docker didn‘t have `wget`, which is causing releases to fail. This fixes the issue (`dumb-init` is now available directly via `apt`, so just use that) and also reconfigures our docker build in CI so that docker builds get tested (we only separate out the actual publishing step now).