### PR TITLE
fixes #658

### DIFF
--- a/src/scripts/__tests__/html-transforms.test.js
+++ b/src/scripts/__tests__/html-transforms.test.js
@@ -16,7 +16,7 @@ describe('HtmlTransforms module', () => {
         <head>
           <link rel="canonical" href="somewhere.html" id="non-style-link">
           <link rel="stylesheet" type="text/css" href="sheet.css" id="external-sheet">
-           <link rel="stylesheet prefetch" type="text/css" href="sheet.css" id="external-sheet">
+          <link rel="stylesheet prefetch" type="text/css" href="sheet.css" id="external-sheet">
           <script type="text/javascript" src="script.js"></script>
           <script type="text/javascript">
             console.log('Inline javascript!');

--- a/src/scripts/__tests__/html-transforms.test.js
+++ b/src/scripts/__tests__/html-transforms.test.js
@@ -16,6 +16,7 @@ describe('HtmlTransforms module', () => {
         <head>
           <link rel="canonical" href="somewhere.html" id="non-style-link">
           <link rel="stylesheet" type="text/css" href="sheet.css" id="external-sheet">
+           <link rel="stylesheet prefetch" type="text/css" href="sheet.css" id="external-sheet">
           <script type="text/javascript" src="script.js"></script>
           <script type="text/javascript">
             console.log('Inline javascript!');

--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -33,7 +33,7 @@ export function compose (...transforms) {
  */
 export function removeStyleAndScript (document) {
   // Stylesheets and scripts
-  document.querySelectorAll('link[rel="stylesheet"], style, script').forEach(node => {
+  document.querySelectorAll('link[rel*="stylesheet"], style, script').forEach(node => {
     const isDiffNode = node.id.startsWith('wm-') ||
       Array.from(node.classList).some(name => name.startsWith('wm-'));
 


### PR DESCRIPTION
Modified the query selector so that it picks all link tags which contain the word "stylesheet" in its rel attribute.
Added a link tag for the same use case in the test case for the function.