### PR TITLE
HOTFIX: Fix references to renamed `version.uri`

### DIFF
--- a/src/components/change-view/change-view.jsx
+++ b/src/components/change-view/change-view.jsx
@@ -394,7 +394,7 @@ function mediaTypeForVersion (version, page) {
     return parseMediaType(version.media_type);
   }
 
-  const extensionType = mediaTypeForUrl(version.uri)
+  const extensionType = mediaTypeForUrl(version.body_url)
     || (page && mediaTypeForUrl(page.url));
 
   return extensionType || htmlType;

--- a/src/components/diff-view.jsx
+++ b/src/components/diff-view.jsx
@@ -199,8 +199,8 @@ export default class DiffView extends React.Component {
     this._loadingDiff = specifier;
     if (!diffTypes[diffType].diffService) {
       return Promise.all([
-        fetch(a.uri, { mode: 'cors' }),
-        fetch(b.uri, { mode: 'cors' })
+        fetch(a.body_url, { mode: 'cors' }),
+        fetch(b.body_url, { mode: 'cors' })
       ])
         .then(([rawA, rawB]) => {
           return { raw: true, rawA, rawB };

--- a/src/components/raw-version.jsx
+++ b/src/components/raw-version.jsx
@@ -27,7 +27,7 @@ export default class RawVersion extends React.Component {
 
     return (
       <div className="inline-render">
-        <iframe src={this.props.version.uri} />
+        <iframe src={this.props.version.body_url} />
       </div>
     );
   }

--- a/src/components/side-by-side-raw-versions.jsx
+++ b/src/components/side-by-side-raw-versions.jsx
@@ -32,5 +32,5 @@ function renderVersion (page, version, content) {
     return <SandboxedHtml html={content} baseUrl={page.url} />;
   }
 
-  return <iframe src={version.uri} />;
+  return <iframe src={version.body_url} />;
 }


### PR DESCRIPTION
This field was renamed and #749 was meant to handle that. It seems we missed several spots.