### PR TITLE
Speed up list view by removing "last capture date"

### DIFF
--- a/src/components/__tests__/page-list.test.jsx
+++ b/src/components/__tests__/page-list.test.jsx
@@ -34,12 +34,22 @@ describe('page-list', () => {
     expect(pageList.get(0)).toBeTruthy();
   });
 
-  it('shows only sites from tags', () => {
+  it('shows domain without www prefix', () => {
     const pageList = shallow(
       <PageList pages={simplePages} />
     );
-    expect(pageList.find('tbody tr').first().childAt(1).text())
-      .toBe('NOAA - ncei.noaa.gov, EPA - www3.epa.gov');
+    expect(pageList.find('tbody tr').first().childAt(0).text())
+      .toBe('ncei.noaa.gov');
+  });
+
+  it('shows non-URL related tags', () => {
+    const pageList = shallow(<PageList pages={simplePages} />);
+    const tagsCell = pageList.find('tbody tr').first().childAt(3);
+
+    expect(tagsCell.children().every('PageTag')).toBe(true);
+    expect(tagsCell.children().length).toBe(1);
+    expect(tagsCell.children().first().props())
+      .toHaveProperty('tag.name', 'Human');
   });
 
   it('displays SearchBar component', () => {

--- a/src/components/page-list/page-list.css
+++ b/src/components/page-list/page-list.css
@@ -67,3 +67,19 @@
 .table > thead:first-child > tr:first-child > th {
   border-top: 0;
 }
+
+.table th[data-name="domain"] {
+  width: 18em;
+}
+
+.page-tag {
+  background: #6c757d;
+  border-radius: 5em;
+  color: white;
+  margin-right: 0.5em;
+  padding: 0.15em 0.5em;
+}
+
+.page-tag--prefix {
+  opacity: 0.75;
+}

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -103,10 +103,7 @@ export default class WebMonitoringUi extends React.Component {
           return Promise.reject(new Error('You must be logged in to view pages'));
         }
 
-        const query = Object.assign(
-          { include_latest: true },
-          this.state.query
-        );
+        const query = Object.assign({}, this.state.query);
 
         return api.getPages(query);
       })


### PR DESCRIPTION
The "last capture date" column in the list view required loading the latest version for each page, which has *major* performance issues (see https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/858). It can take up to a minute to load! Alleviate these issues for now by just dropping that column and not attempting to load data about the latest version of each page.

While we're at it, I added in tags to this view, since we've got newfound empty space and they are probably relevant here.

The list view now looks like:

<img width="1279" alt="Screen Shot 2021-06-22 at 10 16 25 AM" src="https://user-images.githubusercontent.com/74178/122970606-fc5a2300-d342-11eb-9841-660d4d112818.png">
