### PR TITLE
Depend directly on Google Sheets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
+        "@googleapis/sheets": "^0.3.0",
         "babel-plugin-react-css-modules": "^5.2.6",
         "body-parser": "^1.18.3",
         "ejs": "^3.1.6",
         "express": "^4.17.1",
-        "googleapis": "^80.0.0",
         "normalize.css": "^8.0.1",
         "request": "^2.88.0"
       },
@@ -1774,6 +1774,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@googleapis/sheets": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/sheets/-/sheets-0.3.0.tgz",
+      "integrity": "sha512-Axhbw2Hi3IAPyYGC4y8wmE/0aY0NVTieDDc+RMnx2/iSQ8laodWqAUDsUskTdEm4ZB2JD2Z+SU6o3IXktDaG4Q==",
+      "dependencies": {
+        "googleapis-common": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -7160,18 +7171,6 @@
       },
       "bin": {
         "gp12-pem": "build/src/bin/gp12-pem.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/googleapis": {
-      "version": "80.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-80.0.0.tgz",
-      "integrity": "sha512-iHjhcjkjHXYF8XV9W/ckOZfoxlMYYHF1eXoApsVgqs7+81b4NneIJUenGVdi7zCZv0HEPHjP1Lv7RWScPkQyyg==",
-      "dependencies": {
-        "google-auth-library": "^7.0.2",
-        "googleapis-common": "^5.0.2"
       },
       "engines": {
         "node": ">=10"
@@ -15135,6 +15134,14 @@
         "base64-js": "^1.3.0"
       }
     },
+    "@googleapis/sheets": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/sheets/-/sheets-0.3.0.tgz",
+      "integrity": "sha512-Axhbw2Hi3IAPyYGC4y8wmE/0aY0NVTieDDc+RMnx2/iSQ8laodWqAUDsUskTdEm4ZB2JD2Z+SU6o3IXktDaG4Q==",
+      "requires": {
+        "googleapis-common": "^5.0.1"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -19471,15 +19478,6 @@
       "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
       "requires": {
         "node-forge": "^0.10.0"
-      }
-    },
-    "googleapis": {
-      "version": "80.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-80.0.0.tgz",
-      "integrity": "sha512-iHjhcjkjHXYF8XV9W/ckOZfoxlMYYHF1eXoApsVgqs7+81b4NneIJUenGVdi7zCZv0HEPHjP1Lv7RWScPkQyyg==",
-      "requires": {
-        "google-auth-library": "^7.0.2",
-        "googleapis-common": "^5.0.2"
       }
     },
     "googleapis-common": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "web-monitoring-ui",
   "main": "views/main.html",
   "dependencies": {
+    "@googleapis/sheets": "^0.3.0",
     "babel-plugin-react-css-modules": "^5.2.6",
     "body-parser": "^1.18.3",
     "ejs": "^3.1.6",
     "express": "^4.17.1",
-    "googleapis": "^80.0.0",
     "normalize.css": "^8.0.1",
     "request": "^2.88.0"
   },

--- a/server/sheet-data.js
+++ b/server/sheet-data.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const { google } = require('googleapis');
+const googleSheets = require('@googleapis/sheets');
 const config = require('./configuration');
-const sheets = google.sheets('v4');
+const sheets = googleSheets.sheets('v4');
 const formatters = require('../src/scripts/formatters');
 
 function addChangeToDictionary (data) {
@@ -197,7 +197,7 @@ function addAuthentication (requestData) {
       // Replace `\n` in ENV variable with actual line breaks.
       const privateKey = configuration.GOOGLE_SHEETS_PRIVATE_KEY.replace(/\\n/g, '\n');
 
-      authClient = new google.auth.JWT(
+      authClient = new googleSheets.auth.JWT(
         clientEmail,
         null,
         privateKey,


### PR DESCRIPTION
We previously used the `googleapis` dependency, because that mega-package was the only way to load the official Node.js version of Google Sheets. However, Google now publishes individual subpackages for each service, so we can depend directly on `@googleapis/sheets`. This should mean smaller dependencies and *far* less frequent updates.

Fixes #730.