### PR TITLE
Load version subresources from correct URL

### DIFF
--- a/src/components/inline-rendered-diff.jsx
+++ b/src/components/inline-rendered-diff.jsx
@@ -5,6 +5,7 @@ import {
   loadSubresourcesFromWayback,
   compose
 } from '../scripts/html-transforms';
+import { versionUrl } from '../scripts/tools';
 import SandboxedHtml from './sandboxed-html';
 
 /**
@@ -37,7 +38,7 @@ export default class InlineRenderedDiff extends React.Component {
 
     return (
       <div className="inline-render">
-        <SandboxedHtml html={diff} baseUrl={this.props.page.url} transform={transformDocument}/>
+        <SandboxedHtml html={diff} baseUrl={versionUrl(this.props.b)} transform={transformDocument}/>
       </div>
     );
   }

--- a/src/components/side-by-side-rendered-diff.jsx
+++ b/src/components/side-by-side-rendered-diff.jsx
@@ -6,6 +6,7 @@ import {
   compose,
   addTargetBlank
 } from '../scripts/html-transforms';
+import { versionUrl } from '../scripts/tools';
 import SandboxedHtml from './sandboxed-html';
 
 /**
@@ -49,12 +50,12 @@ export default class SideBySideRenderedDiff extends React.Component {
       <div className="side-by-side-render">
         <SandboxedHtml
           html={this.props.diffData.deletions}
-          baseUrl={this.props.page.url}
+          baseUrl={versionUrl(this.props.a)}
           transform={transformA}
         />
         <SandboxedHtml
           html={this.props.diffData.insertions}
-          baseUrl={this.props.page.url}
+          baseUrl={versionUrl(this.props.b)}
           transform={transformB}
         />
       </div>

--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -1,3 +1,5 @@
+import { versionUrl } from './tools';
+
 /**
  * HtmlTransforms are functions that take an HTML Document and modify it in
  * some useful way, such as removing scripts.
@@ -131,12 +133,13 @@ export function addTargetBlank (document) {
  */
 export function loadSubresourcesFromWayback (page, version) {
   return document => {
+    const url = versionUrl(version);
     const timestamp = createWaybackTimestamp(version.capture_time);
     document.querySelectorAll('link[rel="stylesheet"]').forEach(node => {
-      node.href = createWaybackUrl(node.getAttribute('href'), timestamp, page.url);
+      node.href = createWaybackUrl(node.getAttribute('href'), timestamp, url);
     });
     document.querySelectorAll('script[src],img[src]').forEach(node => {
-      node.src = createWaybackUrl(node.getAttribute('src'), timestamp, page.url);
+      node.src = createWaybackUrl(node.getAttribute('src'), timestamp, url);
     });
     // TODO: handle <picture> with all its subelements
     // TODO: SVG <use> directives

--- a/src/scripts/tools.js
+++ b/src/scripts/tools.js
@@ -1,0 +1,23 @@
+/**
+ * Get the URL that a version's body came from. If a version included redirects,
+ * then its `url` property won't corresponded with the URL the response body
+ * was rendered from. This gets the final target URL of all redirects, if there
+ * were any, and otherwise returns the version's `url` property.
+ * @param {Version} version
+ * @returns {string}
+ */
+export function versionUrl (version) {
+  let url = version.url;
+
+  if (version.source_metadata) {
+    if (version.source_metadata.redirected_url) {
+      url = version.source_metadata.redirected_url;
+    }
+    else if (version.source_metadata.redirects) {
+      const redirects = version.source_metadata.redirects;
+      url = redirects[redirects.length - 1];
+    }
+  }
+
+  return url;
+}


### PR DESCRIPTION
We've been using the page's `url` property to determine  the base URL from which to load subresources when showing diffs. However, a page's URL can shift over time, and versions can come from drastically different looking URLs. That means the correct "base" URL for a version depends on the *version,* not the page it's attached to, and also needs to take redirects into account.

For example, a page's URL might have been `https://epa.gov/somewhere`, but one of the versions might have come from `https://epa.gov/somewhere/else`, which itself might have redirected to `https://differentsubdomain.epa.gov/a/whole/other/path`. We've been using the first of those three URLs as the base URL for the version when rendering it in diffs, but this change lets us use the last of those three URLs instead.

Fixes #600.