### PR TITLE
Show monitored status, HTTP status, and tags

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,7 +13,9 @@
   ],
   "plugins": [
     ["react-css-modules", {
-      "attributeNames": { "activeStyleName": "activeClassName" } // for React Router NavLink
+      // for React Router NavLink
+      "attributeNames": { "activeStyleName": "activeClassName" },
+      "handleMissingStyleName": "warn"
     }]
   ]
 }

--- a/src/__mocks__/simple-page.json
+++ b/src/__mocks__/simple-page.json
@@ -2,6 +2,7 @@
   "uuid": "9420d91c-2fd8-411a-a756-5bf976574d10",
   "url": "http://www.ncei.noaa.gov/news/earth-science-conference-convenes",
   "title": "Earth Science Conference Convenes | National Centers for Environmental Information (NCEI)",
+  "active": true,
   "created_at": "2017-05-02T23:55:57.021Z",
   "updated_at": "2018-02-01T05:20:52.203Z",
   "versions": [

--- a/src/__mocks__/simple-pages.json
+++ b/src/__mocks__/simple-pages.json
@@ -3,6 +3,7 @@
     "uuid": "9420d91c-2fd8-411a-a756-5bf976574d10",
     "url": "http://www.ncei.noaa.gov/news/earth-science-conference-convenes",
     "title": "Earth Science Conference Convenes | National Centers for Environmental Information (NCEI)",
+    "active": true,
     "created_at": "2017-05-02T23:55:57.021Z",
     "updated_at": "2018-02-01T05:20:52.203Z",
     "latest": {
@@ -81,6 +82,7 @@
     "uuid": "fba5c998-4f11-4e69-a3ff-66c0a4e9e7d3",
     "url": "https://www3.epa.gov/climatechange/impacts/society.html",
     "title": "Page being updated | US EPA",
+    "active": true,
     "agency": "EPA",
     "site": "EPA - www3.epa.gov",
     "created_at": "2017-11-09T02:50:37Z",

--- a/src/components/page-details/page-details.css
+++ b/src/components/page-details/page-details.css
@@ -26,6 +26,34 @@
   font-size: 1.5em;
   margin-bottom: 0;
   margin-top: 0.3em;
+  margin-right: 0.75em;
+  display: inline;
+}
+
+.info-items {
+  display: inline;
+  margin: 0.1em 0 0.25em;
+}
+
+.info-item {
+  margin-right: 1em;
+}
+
+.info-item[data-page-active="false"] {
+  color: var(--gray-light)
+}
+
+.status-error {
+  color: var(--danger-text);
+  font-weight: bold;
+}
+
+.status-ok {
+  color: inherit;
+}
+
+.page-url {
+  display: block;
 }
 
 .pager {
@@ -67,18 +95,6 @@
 
 .pager-prev .fa {
   margin-right: 0;
-}
-
-.redirect-tooltip {
-  max-width: 50em;
-}
-
-.redirect-tooltip p {
-  padding-left: 1em;
-}
-
-.redirect-tooltip p strong {
-  margin-left: -1em;
 }
 
 @media (max-width: 992px) {

--- a/src/components/page-details/page-details.css
+++ b/src/components/page-details/page-details.css
@@ -37,6 +37,7 @@
 
 .info-item {
   margin-right: 1em;
+  white-space: nowrap;
 }
 
 .info-item[data-page-active="false"] {

--- a/src/components/page-details/page-details.jsx
+++ b/src/components/page-details/page-details.jsx
@@ -9,7 +9,7 @@ import PageUrlDetails from '../page-url-details/page-url-details';
 import PageTag from '../page-tag/page-tag';
 import StandardTooltip from '../standard-tooltip';
 import { describeHttpStatus } from '../../scripts/http-info';
-import { removeNonuserTags } from '../../scripts/tools';
+import { removeNonUserTags } from '../../scripts/tools';
 
 import baseStyles from '../../css/base.css'; // eslint-disable-line
 import pageStyles from './page-details.css'; // eslint-disable-line
@@ -110,7 +110,7 @@ export default class PageDetails extends React.Component {
 
     const statusCode = this.state.page.status || 200;
     const statusError = statusCode >= 400;
-    const tags = removeNonuserTags(this.state.page.tags);
+    const tags = removeNonUserTags(this.state.page.tags);
 
     // TODO: this HTML should probably be broken up a bit
     return (

--- a/src/components/page-details/page-details.jsx
+++ b/src/components/page-details/page-details.jsx
@@ -6,6 +6,10 @@ import ChangeView from '../change-view/change-view';
 import Loading from '../loading';
 import ExternalLink from '../external-link';
 import PageUrlDetails from '../page-url-details/page-url-details';
+import PageTag from '../page-tag/page-tag';
+import StandardTooltip from '../standard-tooltip';
+import { describeHttpStatus } from '../../scripts/http-info';
+import { removeNonuserTags } from '../../scripts/tools';
 
 import baseStyles from '../../css/base.css'; // eslint-disable-line
 import pageStyles from './page-details.css'; // eslint-disable-line
@@ -104,16 +108,41 @@ export default class PageDetails extends React.Component {
       return <Redirect to={`/page/${targetId}/${changeId}`} />;
     }
 
+    const statusCode = this.state.page.status || 200;
+    const statusError = statusCode >= 400;
+    const tags = removeNonuserTags(this.state.page.tags);
+
     // TODO: this HTML should probably be broken up a bit
     return (
       <div styleName="baseStyles.main pageStyles.page-details-main">
+        <StandardTooltip id="page-tooltip" />
         <div styleName="pageStyles.header">
           <header styleName="pageStyles.header-section-title">
             <h2 styleName="pageStyles.page-title">
               {this.state.page.title}
             </h2>
-            <ExternalLink href={this.state.page.url} />
-            <PageUrlDetails page={this.state.page} {...this._versionsToRender()} />
+            <div styleName="pageStyles.info-items">
+              <span
+                styleName="pageStyles.info-item"
+                data-page-active={this.state.page.active.toString()}
+              >
+                {this.state.page.active ? '•' : '✘ Not'} Actively Monitored
+              </span>
+              <span
+                styleName={`pageStyles.info-item pageStyles.${statusError ? 'status-error' : 'status-ok'}`}
+                data-http-status={statusCode}
+                data-for="page-tooltip"
+                data-tip={describeHttpStatus(statusCode)}
+              >
+                {statusError ? '✘' : '•'} HTTP Status: {statusCode}
+              </span>
+              {tags.map(tag => <PageTag tag={tag} key={tag.name} />)}
+            </div>
+            {/* TODO: can we restructure to remove this div? */}
+            <div>
+              <ExternalLink href={this.state.page.url} />
+              <PageUrlDetails page={this.state.page} {...this._versionsToRender()} />
+            </div>
           </header>
           <div styleName="pageStyles.header-section-pager">
             {this._renderPager()}

--- a/src/components/page-details/page-details.jsx
+++ b/src/components/page-details/page-details.jsx
@@ -121,6 +121,7 @@ export default class PageDetails extends React.Component {
             <h2 styleName="pageStyles.page-title">
               {this.state.page.title}
             </h2>
+            {' '}
             <div styleName="pageStyles.info-items">
               <span
                 styleName="pageStyles.info-item"

--- a/src/components/page-list/page-list.css
+++ b/src/components/page-list/page-list.css
@@ -23,20 +23,32 @@
   word-wrap: break-word;
 }
 
-.page-list > tbody > tr > th[data-name="capture-date"] {
+.page-list > thead > tr > th[data-name="capture-date"] {
   width: 12%;
 }
 
-.page-list > tbody > tr > th[data-name="site"] {
+.page-list > thead > tr > th[data-name="site"] {
   width: 15%;
 }
 
-.page-list > tbody > tr > th[data-name="page-name"] {
+.page-list > thead > tr > th[data-name="page-name"] {
   width: 33%;
 }
 
-.page-list > tbody > tr > th[data-name="url"] {
+.page-list > thead > tr > th[data-name="url"] {
   width: 40%;
+}
+
+.page-list > thead > tr > th[data-name="tags"] {
+  width: 30%;
+}
+
+.page-list > thead > tr > th[data-name="status"] {
+  width: 4.5em;
+}
+
+.page-list > thead > tr > th[data-name="active"] {
+  width: 4.5em;
 }
 
 /* .table styles copied from bootstrap */
@@ -72,14 +84,10 @@
   width: 18em;
 }
 
-.page-tag {
-  background: #6c757d;
-  border-radius: 5em;
-  color: white;
-  margin-right: 0.5em;
-  padding: 0.15em 0.5em;
+.page-list [data-page-active="false"] {
+  opacity: 0.5;
 }
 
-.page-tag--prefix {
-  opacity: 0.75;
+.page-list [data-status-category="2xx"] {
+  color: 0.5;
 }

--- a/src/components/page-list/page-list.jsx
+++ b/src/components/page-list/page-list.jsx
@@ -7,7 +7,7 @@ import {
   getHttpStatusCategory,
   describeHttpStatus
 } from '../../scripts/http-info';
-import { removeNonuserTags } from '../../scripts/tools';
+import { removeNonUserTags } from '../../scripts/tools';
 
 import baseStyles from '../../css/base.css'; // eslint-disable-line
 import listStyles from './page-list.css'; // eslint-disable-line
@@ -82,7 +82,7 @@ export default class PageList extends React.Component {
 
   renderRow (record) {
     const onClick = this.didClickRow.bind(this, record);
-    const tags = removeNonuserTags(record.tags);
+    const tags = removeNonUserTags(record.tags);
     const statusCode = record.status || 200;
     let statusCategory = getHttpStatusCategory(statusCode);
 

--- a/src/components/page-tag/page-tag.css
+++ b/src/components/page-tag/page-tag.css
@@ -1,0 +1,11 @@
+.page-tag {
+  background: var(--gray-light);
+  border-radius: 5px;
+  color: white;
+  margin-right: 0.5em;
+  padding: 0.15em 0.4em;
+}
+
+.page-tag--prefix {
+  opacity: 0.75;
+}

--- a/src/components/page-tag/page-tag.jsx
+++ b/src/components/page-tag/page-tag.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styles from './page-tag.css'; // eslint-disable-line
+
+/**
+ * Helper component for rendering tags.
+ */
+export default function PageTag ({ tag }) {
+  let prefix = '';
+  let name = tag.name;
+  const colonIndex = name.indexOf(':');
+  if (colonIndex > -1) {
+    prefix = name.slice(0, colonIndex + 1);
+    name = name.slice(colonIndex + 1);
+  }
+
+  let prefixNode;
+  if (prefix) {
+    prefixNode = <span styleName="styles.page-tag--prefix">{prefix}</span>;
+  }
+
+  return (
+    <span styleName="styles.page-tag">
+      {prefixNode}
+      {name}
+    </span>
+  );
+}

--- a/src/components/page-url-details/page-url-details.css
+++ b/src/components/page-url-details/page-url-details.css
@@ -1,4 +1,5 @@
 .page-url-details {
+  margin: 0.25em 0 0;
   padding: 0 1em;
 }
 

--- a/src/scripts/http-info.js
+++ b/src/scripts/http-info.js
@@ -1,0 +1,90 @@
+export const HTTP_STATUS_DESCRIPTION = {
+  '1xx': 'Informational',
+  '100': 'Continue',
+  '101': 'Switching Protocols',
+  '102': 'Processing',
+
+  '2xx': 'Success',
+  '200': 'OK',
+  '201': 'Created',
+  '202': 'Accepted',
+  '203': 'Non-authoritative Information',
+  '204': 'No Content',
+  '205': 'Reset Content',
+  '206': 'Partial Content',
+  '207': 'Multi-Status',
+  '208': 'Already Reported',
+  '226': 'IM Used',
+  '3××': 'Redirection',
+  '300': 'Multiple Choices',
+  '301': 'Moved Permanently',
+  '302': 'Found',
+  '303': 'See Other',
+  '304': 'Not Modified',
+  '305': 'Use Proxy',
+  '307': 'Temporary Redirect',
+  '308': 'Permanent Redirect',
+
+  '4xx': 'Client/User Error',
+  '400': 'Bad Request',
+  '401': 'Unauthorized',
+  '402': 'Payment Required',
+  '403': 'Forbidden',
+  '404': 'Not Found',
+  '405': 'Method Not Allowed',
+  '406': 'Not Acceptable',
+  '407': 'Proxy Authentication Required',
+  '408': 'Request Timeout',
+  '409': 'Conflict',
+  '410': 'Gone',
+  '411': 'Length Required',
+  '412': 'Precondition Failed',
+  '413': 'Payload Too Large',
+  '414': 'Request-URI Too Long',
+  '415': 'Unsupported Media Type',
+  '416': 'Requested Range Not Satisfiable',
+  '417': 'Expectation Failed',
+  '418': 'I\'m a teapot',
+  '421': 'Misdirected Request',
+  '422': 'Unprocessable Entity',
+  '423': 'Locked',
+  '424': 'Failed Dependency',
+  '426': 'Upgrade Required',
+  '428': 'Precondition Required',
+  '429': 'Too Many Requests',
+  '431': 'Request Header Fields Too Large',
+  '444': 'Connection Closed Without Response',
+  '451': 'Unavailable For Legal Reasons',
+  '499': 'Client Closed Request',
+
+  '5xx': 'Server Error',
+  '500': 'Internal Server Error',
+  '501': 'Not Implemented',
+  '502': 'Bad Gateway',
+  '503': 'Service Unavailable',
+  '504': 'Gateway Timeout',
+  '505': 'HTTP Version Not Supported',
+  '506': 'Variant Also Negotiates',
+  '507': 'Insufficient Storage',
+  '508': 'Loop Detected',
+  '510': 'Not Extended',
+  '511': 'Network Authentication Required',
+  '599': 'Network Connect Timeout Error'
+};
+
+export function getHttpStatusCategory (statusCode, defaultCode = 200) {
+  if (!statusCode) statusCode = defaultCode;
+
+  return `${Math.floor(statusCode / 100)}xx`;
+}
+
+export function describeHttpStatus (statusCode, defaultCode = 200) {
+  if (!statusCode) statusCode = defaultCode;
+
+  const statusCategory = getHttpStatusCategory(statusCode);
+  return `
+    ${statusCode}: ${HTTP_STATUS_DESCRIPTION[statusCode]}
+    (${statusCategory} codes indicate
+    ${HTTP_STATUS_DESCRIPTION[statusCategory]})
+  `;
+}

--- a/src/scripts/tools.js
+++ b/src/scripts/tools.js
@@ -1,3 +1,11 @@
+export const NON_USER_TAGS = ['site:', '2l-domain:', 'domain:'];
+
+export function removeNonuserTags (tags) {
+  return tags.filter(tag =>
+    !NON_USER_TAGS.some(prefix => tag.name.startsWith(prefix))
+  );
+}
+
 /**
  * Get the URL that a version's body came from. If a version included redirects,
  * then its `url` property won't corresponded with the URL the response body

--- a/src/scripts/tools.js
+++ b/src/scripts/tools.js
@@ -1,6 +1,6 @@
 export const NON_USER_TAGS = ['site:', '2l-domain:', 'domain:'];
 
-export function removeNonuserTags (tags) {
+export function removeNonUserTags (tags) {
   return tags.filter(tag =>
     !NON_USER_TAGS.some(prefix => tag.name.startsWith(prefix))
   );


### PR DESCRIPTION
This adds the page’s monitored status (i.e. whether we are recording new versions) and the HTTP status to both the list view and the page details view. It also adds tags to the page details view.

List view:

<img width="1278" alt="Screen Shot 2021-07-09 at 10 13 45 AM" src="https://user-images.githubusercontent.com/74178/125114686-23348b00-e09f-11eb-96a2-1568db5ec27b.png">

Details view:

<img width="1280" alt="Screen Shot 2021-07-09 at 10 17 58 AM" src="https://user-images.githubusercontent.com/74178/125114709-2af42f80-e09f-11eb-9cd0-9feadbc64eb8.png">

The DOM structure on the page details view has gotten a bit messy, and it would be good to clean up. I don't think that's worth blocking this for, though.

Fixes #331.