### PR TITLE
Upgrade Bundlewatch to v0.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "web-monitoring-ui",
       "version": "0.1.0",
-      "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
         "@googleapis/sheets": "^0.3.0",
@@ -27,7 +26,7 @@
         "autoprefixer": "^10.4.1",
         "babel-core": "^7.0.0-bridge.0",
         "babel-loader": "^8.2.3",
-        "bundlewatch": "^0.3.2",
+        "bundlewatch": "^0.3.3",
         "compression-webpack-plugin": "^9.2.0",
         "css-loader": "^3.6.0",
         "dotenv": "^10.0.0",
@@ -3283,12 +3282,12 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "node_modules/axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/babel-code-frame": {
@@ -4634,18 +4633,18 @@
       "dev": true
     },
     "node_modules/bundlewatch": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/bundlewatch/-/bundlewatch-0.3.2.tgz",
-      "integrity": "sha512-gqekMv+ph1vKjM2B6P7mk8HxNZ3ZLOU94Vo3eFqPgQ0COqDsYcrPwsmpczAwsPxOMY7ZpKCGUez7shbdttCDew==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/bundlewatch/-/bundlewatch-0.3.3.tgz",
+      "integrity": "sha512-qzSVWrZyyWXa546JpAPRPTFmnXms9YNVnfzB05DRJKmN6wRRa7SkxE4OgKQmbAY74Z6CM2mKAc6vwvd2R+1lUQ==",
       "dev": true,
       "dependencies": {
-        "axios": "^0.21.1",
-        "bytes": "^3.0.0",
+        "axios": "^0.24.0",
+        "bytes": "^3.1.1",
         "chalk": "^4.0.0",
-        "ci-env": "^1.14.0",
+        "ci-env": "^1.17.0",
         "commander": "^5.0.0",
         "glob": "^7.1.2",
-        "gzip-size": "^5.1.1",
+        "gzip-size": "^6.0.0",
         "jsonpack": "^1.1.5",
         "lodash.merge": "^4.6.1",
         "read-pkg-up": "^7.0.1"
@@ -4845,9 +4844,9 @@
       }
     },
     "node_modules/ci-env": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.16.0.tgz",
-      "integrity": "sha512-ucF9caQEX5wQlY449KZBIJPx91+kRg9tJ3tWSc4+KzrvC5KNiPm/3g1noP8VhdI3046+Vw3jLmKAD0fjCRJTmw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.17.0.tgz",
+      "integrity": "sha512-NtTjhgSEqv4Aj90TUYHQLxHdnCPXnjdtuGG1X8lTfp/JqeXTdw0FTWl/vUAPuvbWZTF8QVpv6ASe/XacE+7R2A==",
       "dev": true
     },
     "node_modules/ci-info": {
@@ -7114,9 +7113,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
-      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "dev": true,
       "funding": [
         {
@@ -7507,16 +7506,18 @@
       }
     },
     "node_modules/gzip-size": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
-      "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
       "dev": true,
       "dependencies": {
-        "duplexer": "^0.1.1",
-        "pify": "^4.0.1"
+        "duplexer": "^0.1.2"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/har-schema": {
@@ -11219,15 +11220,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/pirates": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.4.tgz",
@@ -13679,21 +13671,6 @@
       "dev": true,
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/gzip-size": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
-      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
-      "dev": true,
-      "dependencies": {
-        "duplexer": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/has-flag": {
@@ -16524,12 +16501,12 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.4"
       }
     },
     "babel-code-frame": {
@@ -17732,18 +17709,18 @@
       "dev": true
     },
     "bundlewatch": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/bundlewatch/-/bundlewatch-0.3.2.tgz",
-      "integrity": "sha512-gqekMv+ph1vKjM2B6P7mk8HxNZ3ZLOU94Vo3eFqPgQ0COqDsYcrPwsmpczAwsPxOMY7ZpKCGUez7shbdttCDew==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/bundlewatch/-/bundlewatch-0.3.3.tgz",
+      "integrity": "sha512-qzSVWrZyyWXa546JpAPRPTFmnXms9YNVnfzB05DRJKmN6wRRa7SkxE4OgKQmbAY74Z6CM2mKAc6vwvd2R+1lUQ==",
       "dev": true,
       "requires": {
-        "axios": "^0.21.1",
-        "bytes": "^3.0.0",
+        "axios": "^0.24.0",
+        "bytes": "^3.1.1",
         "chalk": "^4.0.0",
-        "ci-env": "^1.14.0",
+        "ci-env": "^1.17.0",
         "commander": "^5.0.0",
         "glob": "^7.1.2",
-        "gzip-size": "^5.1.1",
+        "gzip-size": "^6.0.0",
         "jsonpack": "^1.1.5",
         "lodash.merge": "^4.6.1",
         "read-pkg-up": "^7.0.1"
@@ -17887,9 +17864,9 @@
       "dev": true
     },
     "ci-env": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.16.0.tgz",
-      "integrity": "sha512-ucF9caQEX5wQlY449KZBIJPx91+kRg9tJ3tWSc4+KzrvC5KNiPm/3g1noP8VhdI3046+Vw3jLmKAD0fjCRJTmw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.17.0.tgz",
+      "integrity": "sha512-NtTjhgSEqv4Aj90TUYHQLxHdnCPXnjdtuGG1X8lTfp/JqeXTdw0FTWl/vUAPuvbWZTF8QVpv6ASe/XacE+7R2A==",
       "dev": true
     },
     "ci-info": {
@@ -19611,9 +19588,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
-      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "dev": true
     },
     "forever-agent": {
@@ -19891,13 +19868,12 @@
       }
     },
     "gzip-size": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
-      "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
       "dev": true,
       "requires": {
-        "duplexer": "^0.1.1",
-        "pify": "^4.0.1"
+        "duplexer": "^0.1.2"
       }
     },
     "har-schema": {
@@ -22679,12 +22655,6 @@
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
     },
-    "pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true
-    },
     "pirates": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.4.tgz",
@@ -24608,15 +24578,6 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
           "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
           "dev": true
-        },
-        "gzip-size": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
-          "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
-          "dev": true,
-          "requires": {
-            "duplexer": "^0.1.2"
-          }
         },
         "has-flag": {
           "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "autoprefixer": "^10.4.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.2.3",
-    "bundlewatch": "^0.3.2",
+    "bundlewatch": "^0.3.3",
     "compression-webpack-plugin": "^9.2.0",
     "css-loader": "^3.6.0",
     "dotenv": "^10.0.0",


### PR DESCRIPTION
Fixes a security vulnerability. Does not require a release, since this is development-only.