### PR TITLE
Stop importing React unnecessarily

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,7 +9,9 @@
       // Preview the results a query at: https://browserl.ist/
       // "targets": "xyz"
     }],
-    "@babel/preset-react"
+    ["@babel/preset-react", {
+      "runtime": "automatic"
+    }]
   ],
   "plugins": [
     ["react-css-modules", {

--- a/src/components/__tests__/change-view.test.jsx
+++ b/src/components/__tests__/change-view.test.jsx
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import React from 'react';
 import { shallow } from 'enzyme';
 import ChangeView, { defaultDiffType, diffTypeStorage } from '../change-view/change-view';
 import layeredStorage from '../../scripts/layered-storage';

--- a/src/components/__tests__/diff-view.test.jsx
+++ b/src/components/__tests__/diff-view.test.jsx
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 import DiffView from '../diff-view';
-import React from 'react';
 import { shallow } from 'enzyme';
 import simplePage from '../../__mocks__/simple-page.json';
 import WebMonitoringDb from '../../services/web-monitoring-db';

--- a/src/components/__tests__/environment-banner.test.jsx
+++ b/src/components/__tests__/environment-banner.test.jsx
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 import EnvironmentBanner from '../environment-banner/environment-banner';
-import React from 'react';
 import { mount } from 'enzyme';
 
 describe('EnvironmentBanner', () => {

--- a/src/components/__tests__/login-form.test.jsx
+++ b/src/components/__tests__/login-form.test.jsx
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import React from 'react';
 import { shallow } from 'enzyme';
 import LoginPanel from '../login-form/login-form';
 import WebMonitoringDb from '../../services/web-monitoring-db';

--- a/src/components/__tests__/nav-bar.test.jsx
+++ b/src/components/__tests__/nav-bar.test.jsx
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import React from 'react';
 import { shallow } from 'enzyme';
 import NavBar from '../nav-bar/nav-bar';
 

--- a/src/components/__tests__/page-details.test.jsx
+++ b/src/components/__tests__/page-details.test.jsx
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 import PageDetails from '../page-details/page-details';
-import React from 'react';
 import { shallow } from 'enzyme';
 import simplePage from '../../__mocks__/simple-page.json';
 import WebMonitoringDb from '../../services/web-monitoring-db';

--- a/src/components/__tests__/page-list.test.jsx
+++ b/src/components/__tests__/page-list.test.jsx
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 import PageList from '../page-list/page-list';
-import React from 'react';
 import SearchBar from '../search-bar/search-bar';
 import Loading from '../loading';
 import { shallow } from 'enzyme';

--- a/src/components/__tests__/page-url-details.test.jsx
+++ b/src/components/__tests__/page-url-details.test.jsx
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 import PageUrlDetails from '../page-url-details/page-url-details';
-import React from 'react';
 import { mount } from 'enzyme';
 import simplePage from '../../__mocks__/simple-page.json';
 

--- a/src/components/__tests__/sandboxed-html.test.jsx
+++ b/src/components/__tests__/sandboxed-html.test.jsx
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import React from 'react';
 import { mount } from 'enzyme';
 import SandboxedHtml from '../sandboxed-html';
 

--- a/src/components/__tests__/search-bar.test.jsx
+++ b/src/components/__tests__/search-bar.test.jsx
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import React from 'react';
 import { shallow, mount } from 'enzyme';
 import SearchBar from '../search-bar/search-bar';
 import moment from 'moment';

--- a/src/components/__tests__/source-info.test.jsx
+++ b/src/components/__tests__/source-info.test.jsx
@@ -1,12 +1,11 @@
 /* eslint-env jest */
 
-import React from 'react';
 import { shallow } from 'enzyme';
 import SourceInfo from '../source-info/source-info';
 
 describe('source-info', () => {
   const noViewUrl = {
-    source_type: 'versionista', 
+    source_type: 'versionista',
     source_metadata: {
       url: 'https://versionista.com/1111/2222/3333/',
       account: 'versionista1',

--- a/src/components/annotation-form.jsx
+++ b/src/components/annotation-form.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Component } from 'react';
 import StandardTooltip from './standard-tooltip';
 
 /**
@@ -13,10 +13,10 @@ import StandardTooltip from './standard-tooltip';
  * Form layout for marking/viewing simple annotations of changes.
  *
  * @class AnnotationForm
- * @extends {React.Component}
+ * @extends {Component}
  * @param {AnnotationFormProps} props
  */
-export default class AnnotationForm extends React.Component {
+export default class AnnotationForm extends Component {
   constructor (props) {
     super(props);
     this._onFieldChange = this._onFieldChange.bind(this);

--- a/src/components/change-view/change-view.jsx
+++ b/src/components/change-view/change-view.jsx
@@ -5,7 +5,7 @@ import DiffView from '../diff-view';
 import layeredStorage from '../../scripts/layered-storage';
 import Loading from '../loading';
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Component } from 'react';
 import SelectDiffType from '../select-diff-type';
 import SelectVersion from '../select-version';
 import SourceInfo from '../source-info/source-info';
@@ -41,10 +41,10 @@ const diffSettingsStorage = 'edgi.wm.ui.diff_settings';
  * Display a change between two versions of a page.
  *
  * @class ChangeView
- * @extends {React.Component}
+ * @extends {Component}
  * @param {ChangeViewProps} props
  */
-export default class ChangeView extends React.Component {
+export default class ChangeView extends Component {
   static getDerivedStateFromProps (props, state) {
     // Ensure that the current diff type is relevant to the content we are
     // comparing. If not, switch to a relevant type.

--- a/src/components/changes-only-diff.jsx
+++ b/src/components/changes-only-diff.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Component } from 'react';
 import DiffItem from './diff-item';
 import List from './list';
 
@@ -11,12 +11,12 @@ const maxContextLineLength = 300;
  * Display a plaintext diff with additions and removals inline.
  *
  * @class ChangesOnlyDiff
- * @extends {React.Component}
+ * @extends {Component}
  * @param {Object} props
  * @param {DiffData} props.diffData
  * @param {string} props.className
  */
-export default class ChangesOnlyDiff extends React.Component {
+export default class ChangesOnlyDiff extends Component {
   render () {
     const changesOnly = this.props.diffData.diff.reduce(
       getContextualDiff, []);

--- a/src/components/diff-item.jsx
+++ b/src/components/diff-item.jsx
@@ -1,12 +1,12 @@
-import React from 'react';
+import { Component } from 'react';
 
 /**
  * Display a single deleted/added/unchanged element within a diff
  *
  * @class DiffItem
- * @extends {React.Component}
+ * @extends {Component}
  */
-export default class DiffItem extends React.Component {
+export default class DiffItem extends Component {
   render () {
     const { data, onSelect } = this.props;
 
@@ -41,8 +41,8 @@ export default class DiffItem extends React.Component {
 }
 
 // DiffItem.propTypes = {
-//   data: React.PropTypes.object.isRequired,
-//   onSelect: React.PropTypes.func,
+//   data: PropTypes.object.isRequired,
+//   onSelect: PropTypes.func,
 // };
 
 // DiffItem.defaultProps = {

--- a/src/components/diff-settings-form.jsx
+++ b/src/components/diff-settings-form.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { PureComponent } from 'react';
 
 // Diff types that we can remove formatting from
 const typesWithFormatting = ['SIDE_BY_SIDE_RENDERED', 'HIGHLIGHTED_RENDERED'];
@@ -16,10 +16,10 @@ const mergeObjects = (...objects) => Object.assign({}, ...objects);
 /**
  * A form for changing settings related to a diff, like whether to remove
  * formatting from it.
- * @extends {React.PureComponent}
+ * @extends {PureComponent}
  * @param {DiffSettingsFormProps} props
  */
-export default class DiffSettingsForm extends React.PureComponent {
+export default class DiffSettingsForm extends PureComponent {
   constructor (props) {
     super(props);
 

--- a/src/components/diff-view.jsx
+++ b/src/components/diff-view.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Component } from 'react';
 import WebMonitoringDb from '../services/web-monitoring-db';
 import { diffTypes } from '../constants/diff-types';
 import Loading from './loading';
@@ -26,10 +26,10 @@ import '../css/base.css';
  * Fetches and renders all sorts of diffs between two versions (props a and b)
  *
  * @class DiffView
- * @extends {React.Component}
+ * @extends {Component}
  * @param {DiffViewProps} props
  */
-export default class DiffView extends React.Component {
+export default class DiffView extends Component {
   static getDerivedStateFromProps (props, state) {
     // Clear out stale diff data before trying to render
     if (!specifiesSameDiff(props, state.previousDiff)) {

--- a/src/components/environment-banner/environment-banner.jsx
+++ b/src/components/environment-banner/environment-banner.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Component } from 'react';
 import './environment-banner.css';
 
 /**
@@ -10,10 +10,10 @@ import './environment-banner.css';
  * A banner to conditionally display warnings to users about the environment.
  *
  * @class EnvironmentBanner
- * @extends {React.Component}
+ * @extends {Component}
  * @param {EnvironmentBannerProps} props
  */
-export default class EnvironmentBanner extends React.Component {
+export default class EnvironmentBanner extends Component {
   constructor (props) {
     super(props);
     this.state = {

--- a/src/components/external-link.jsx
+++ b/src/components/external-link.jsx
@@ -1,10 +1,8 @@
-import React from 'react';
-
 /**
  * Create a link that opens in a new tab/window with no referer information.
  * @param {any} props
  * @param {string} props.href URL of the link
- * @returns React.Component
+ * @returns {React.Component}
  */
 export default function ExternalLink ({ href, children, ...otherProps }) {
   return (

--- a/src/components/highlighted-text-diff.jsx
+++ b/src/components/highlighted-text-diff.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Component } from 'react';
 import DiffItem from './diff-item';
 import List from './list';
 
@@ -6,12 +6,12 @@ import List from './list';
  * Display a plaintext diff with additions and removals inline.
  *
  * @class HighlightedTextDiff
- * @extends {React.Component}
+ * @extends {Component}
  * @param {Object} props
  * @param {DiffData} props.diffData
  * @param {string} props.className
  */
-export default class HighlightedTextDiff extends React.Component {
+export default class HighlightedTextDiff extends Component {
   render () {
     return (
       <List

--- a/src/components/inline-rendered-diff.jsx
+++ b/src/components/inline-rendered-diff.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Component } from 'react';
 
 import {
   removeStyleAndScript,
@@ -22,10 +22,10 @@ import SandboxedHtml from './sandboxed-html';
  * Display two versions of a page with their changes inline together.
  *
  * @class InlineRenderedDiff
- * @extends {React.Component}
+ * @extends {Component}
  * @param {InlineRenderedDiffProps} props
  */
-export default class InlineRenderedDiff extends React.Component {
+export default class InlineRenderedDiff extends Component {
   render () {
     const diff = this.props.diffData.combined || this.props.diffData.diff;
     const transformDocument = compose(

--- a/src/components/list.jsx
+++ b/src/components/list.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import { Component } from 'react';
 
 // Basic list component taken from http://github.com/datatogether/context
 // List accepts an array of data, and an item component. It iterates through the
 // data array, creating an item component for each item in the array, passing
 // it a prop "data" with the array element.
-export default class List extends React.Component {
+export default class List extends Component {
   // const List = (props) => {
   render () {
     // This strange props destructuring is so props.component

--- a/src/components/loading.jsx
+++ b/src/components/loading.jsx
@@ -1,7 +1,7 @@
 import infinityLoaderPath from '../img/infinity-loader.svg';
-import React from 'react';
+import { Component } from 'react';
 
-export default class Loading extends React.Component {
+export default class Loading extends Component {
   render () {
     return (
       <div className="loading">

--- a/src/components/login-form/login-form.jsx
+++ b/src/components/login-form/login-form.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Component } from 'react';
 import WebMonitoringDb from '../../services/web-monitoring-db';
 
 import baseStyles from '../../css/base.css'; // eslint-disable-line
@@ -24,9 +24,9 @@ import formStyles from './login-form.css'; // eslint-disable-line
  * session tokens for the user when they log in.
  *
  * @class LoginPannel
- * @extends {React.Component}
+ * @extends {Component}
  */
-export default class LoginPanel extends React.Component {
+export default class LoginPanel extends Component {
   constructor (props) {
     super(props);
     this.state = { email: '', password: '', error: null };

--- a/src/components/nav-bar/nav-bar.jsx
+++ b/src/components/nav-bar/nav-bar.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link, NavLink } from 'react-router-dom';
 
 import baseStyles from '../../css/base.css'; // eslint-disable-line

--- a/src/components/page-details/page-details.jsx
+++ b/src/components/page-details/page-details.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Component } from 'react';
 import { Link, Redirect } from 'react-router-dom';
 import WebMonitoringDb from '../../services/web-monitoring-db';
 import ChangeView from '../change-view/change-view';
@@ -26,10 +26,10 @@ const cutoffDate = '2000-01-01';
  * Renders detailed, full-screen view of a page and its versions, changes, etc.
  *
  * @class PageDetails
- * @extends {React.Component}
+ * @extends {Component}
  * @param {PageDetailsProps} props
  */
-export default class PageDetails extends React.Component {
+export default class PageDetails extends Component {
   static getDerivedStateFromProps (props, state) {
     // Clear existing content when switching pages
     if (state.page && state.page.uuid !== props.match.params.pageId) {

--- a/src/components/page-list/page-list.jsx
+++ b/src/components/page-list/page-list.jsx
@@ -1,5 +1,5 @@
 import Loading from '../loading';
-import React from 'react';
+import { Component } from 'react';
 import SearchBar from '../search-bar/search-bar';
 import StandardTooltip from '../standard-tooltip';
 import PageTag from '../page-tag/page-tag';
@@ -23,10 +23,10 @@ import listStyles from './page-list.css'; // eslint-disable-line
  * Display a list of pages.
  *
  * @class PageList
- * @extends {React.Component}
+ * @extends {Component}
  * @param {PageListProps} props
  */
-export default class PageList extends React.Component {
+export default class PageList extends Component {
   render () {
     let results;
 

--- a/src/components/page-tag/page-tag.jsx
+++ b/src/components/page-tag/page-tag.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from './page-tag.css'; // eslint-disable-line
 
 /**

--- a/src/components/page-url-details/page-url-details.jsx
+++ b/src/components/page-url-details/page-url-details.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ExternalLink from '../external-link';
 import styles from './page-url-details.css'; // eslint-disable-line
 

--- a/src/components/raw-version.jsx
+++ b/src/components/raw-version.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Component } from 'react';
 import SandboxedHtml from './sandboxed-html';
 
 /**
@@ -12,10 +12,10 @@ import SandboxedHtml from './sandboxed-html';
  * Display the raw content of a version.
  *
  * @class RawVersion
- * @extends {React.Component}
+ * @extends {Component}
  * @param {RawVersionProps} props
  */
-export default class RawVersion extends React.Component {
+export default class RawVersion extends Component {
   render () {
     if (this.props.content && /^[\s\n\r]*</.test(this.props.content)) {
       return (

--- a/src/components/sandboxed-html.jsx
+++ b/src/components/sandboxed-html.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { PureComponent } from 'react';
 
 /**
  * @typedef {Object} SandboxedHtmlProps
@@ -12,10 +12,10 @@ import React from 'react';
  * Display HTML source code or document in a sandboxed frame.
  *
  * @class SandboxedHtml
- * @extends {React.Component}
- * @params {SandboxedHtmlProps} props
+ * @extends {PureComponent}
+ * @param {SandboxedHtmlProps} props
  */
-export default class SandboxedHtml extends React.PureComponent {
+export default class SandboxedHtml extends PureComponent {
   constructor (props) {
     super(props);
     this._frame = null;

--- a/src/components/search-bar/search-bar.jsx
+++ b/src/components/search-bar/search-bar.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Component } from 'react';
 import './search-bar.css';
 import SearchDatePicker from '../search-date-picker';
 
@@ -19,10 +19,10 @@ import SearchDatePicker from '../search-date-picker';
  * Calls onSearch function with SearchBarQuery when query state object is updated.
  *
  * @class SearchBar
- * @extends {React.Component}
+ * @extends {Component}
  * @param {SearchBarProps} props
  */
-export default class SearchBar extends React.Component {
+export default class SearchBar extends Component {
   constructor (props) {
     super(props);
     this.state = {

--- a/src/components/search-date-picker.jsx
+++ b/src/components/search-date-picker.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Component } from 'react';
 import 'react-dates/initialize';
 import { DateRangePicker } from 'react-dates';
 import 'react-dates/lib/css/_datepicker.css';
@@ -18,10 +18,10 @@ import { isInclusivelyBeforeDay } from 'react-dates';
  * Dates can also be cleared out after selected.
  *
  * @class SearchDatePicker
- * @extends {React.Component}
+ * @extends {Component}
  * @param {SearchDatePickerProps} props
  */
-export default class SearchDatePicker extends React.Component {
+export default class SearchDatePicker extends Component {
   constructor (props) {
     super(props);
     this.state = { focusedInput: null };

--- a/src/components/select-diff-type.jsx
+++ b/src/components/select-diff-type.jsx
@@ -1,17 +1,17 @@
-import React from 'react';
+import { Component } from 'react';
 
 /**
  * A dropdown select box for types of diffs
  *
  * @class SelectDiffType
- * @extends {React.Component}
+ * @extends {Component}
  * @param {Object} props
  * @param {string} value Identifier for the selected diff type
  * @param {Function} onChange Callback when a new value is selected. Signature:
  *                            `string => void`
  * @param {DiffType[]} types
  */
-export default class SelectDiffType extends React.Component {
+export default class SelectDiffType extends Component {
   render () {
     const handleChange = (event) => {
       this.props.onChange(event.target.value);

--- a/src/components/select-version.jsx
+++ b/src/components/select-version.jsx
@@ -1,17 +1,17 @@
-import React from 'react';
+import { PureComponent } from 'react';
 import { dateFormatter } from '../scripts/formatters';
 
 /**
  * A select dropdown listing page versions
  *
  * @class SelectVersion
- * @extends {React.PureComponent}
+ * @extends {PureComponent}
  * @param {Object} props
  * @param {Version} [props.value] The currently selected version
  * @param {Version[]} props.versions The list of versions to display
  * @param {Version} props.onChange Callback for new selection. `Version => void`
  */
-export default class SelectVersion extends React.PureComponent {
+export default class SelectVersion extends PureComponent {
   render () {
     const value = this.props.value ? this.props.value.uuid : '';
     const versions = this.props.versions;

--- a/src/components/side-by-side-raw-versions.jsx
+++ b/src/components/side-by-side-raw-versions.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Component } from 'react';
 import SandboxedHtml from './sandboxed-html';
 
 /**
@@ -13,10 +13,10 @@ import SandboxedHtml from './sandboxed-html';
  * Display two versions of a page, side-by-side.
  *
  * @class SideBySideRawVersions
- * @extends {React.Component}
+ * @extends {Component}
  * @param {SideBySideRawVersionsProps} props
  */
-export default class SideBySideRawVersions extends React.Component {
+export default class SideBySideRawVersions extends Component {
   render () {
     return (
       <div className="side-by-side-render">

--- a/src/components/side-by-side-rendered-diff.jsx
+++ b/src/components/side-by-side-rendered-diff.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Component } from 'react';
 import {
   removeStyleAndScript,
   removeClientRedirect,
@@ -23,10 +23,10 @@ import SandboxedHtml from './sandboxed-html';
  * Display two versions of a page, side-by-side.
  *
  * @class SideBySideRenderedDiff
- * @extends {React.Component}
+ * @extends {Component}
  * @param {SideBySideRenderedDiffProps} props
  */
-export default class SideBySideRenderedDiff extends React.Component {
+export default class SideBySideRenderedDiff extends Component {
   render () {
     const baseTransform = compose(
       this.props.removeFormatting && removeStyleAndScript,

--- a/src/components/source-info/source-info.jsx
+++ b/src/components/source-info/source-info.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Component } from 'react';
 import './source-info.css';
 
 /**
@@ -13,7 +13,7 @@ import './source-info.css';
  * If one or both of the versions were sourced from Wayback, this component renders links to the Wayback Machine source url(s)
  *
  * @class SourceInfo
- * @extends {React.Component}
+ * @extends {Component}
  * @param {SourceInfoProps} props
  */
 
@@ -21,7 +21,7 @@ const sourceTypeName = {
   internet_archive: 'Wayback Machine'
 };
 
-export default class SourceInfo extends React.Component {
+export default class SourceInfo extends Component {
   render () {
     const waybackCalendarUrl = `https://web.archive.org/web/*/${this.props.pageUrl}`;
     const waybackCalendarLink = (

--- a/src/components/standard-tooltip.jsx
+++ b/src/components/standard-tooltip.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Tooltip from 'react-tooltip';
 
 export default function StandardTooltip (props) {

--- a/src/components/version-redirect.jsx
+++ b/src/components/version-redirect.jsx
@@ -1,12 +1,12 @@
 import Loading from './loading';
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Component } from 'react';
 import { Redirect } from 'react-router-dom';
 import WebMonitoringDb from '../services/web-monitoring-db';
 
 import '../css/base.css';
 
-export default class VersionRedirect extends React.Component {
+export default class VersionRedirect extends Component {
   constructor (props) {
     super (props);
     this.state = {

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { Component } from 'react';
 import AriaModal from 'react-aria-modal';
 import { BrowserRouter as Router, Redirect, Route } from 'react-router-dom';
 import WebMonitoringApi from '../services/web-monitoring-api';
@@ -27,9 +27,9 @@ const localApi = new WebMonitoringApi(api);
  * with the same filters and conditions.
  *
  * @class WebMonitoringUi
- * @extends {React.Component}
+ * @extends {Component}
  */
-export default class WebMonitoringUi extends React.Component {
+export default class WebMonitoringUi extends Component {
   constructor (props) {
     super(props);
     this.state = {

--- a/src/scripts/bind-component.js
+++ b/src/scripts/bind-component.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createElement } from 'react';
 
 /**
  * Similar to function.bind, but binds props to component types. Returns a
@@ -30,5 +30,5 @@ export default function bindComponent (props, Component) {
   if (!Component) {
     return bindComponent.bind(null, props);
   }
-  return (addedProps) => React.createElement(Component, Object.assign({}, props, addedProps));
+  return (addedProps) => createElement(Component, Object.assign({}, props, addedProps));
 }

--- a/src/scripts/main.jsx
+++ b/src/scripts/main.jsx
@@ -2,7 +2,6 @@ import 'normalize.css';
 import '../css/styles.css';
 import '../css/diff.css';
 import '../css/global.css';
-import React from 'react';
 import ReactDOM from 'react-dom';
 import WebMonitoringUi from '../components/web-monitoring-ui';
 


### PR DESCRIPTION
As of Babel 7.9 and React 16.14.0 or 17.0.0, we no longer need to `import Rect from 'react'` to be able to use JSX syntax; it now happens automatically.