### PR TITLE
Use new sample endpoint to load less data

### DIFF
--- a/src/components/page-details/page-details.jsx
+++ b/src/components/page-details/page-details.jsx
@@ -14,8 +14,6 @@ import { removeNonUserTags } from '../../scripts/tools';
 import baseStyles from '../../css/base.css'; // eslint-disable-line
 import pageStyles from './page-details.css'; // eslint-disable-line
 
-const cutoffDate = '2000-01-01';
-
 /**
  * @typedef {Object} PageDetailsProps
  * @property {Page[]} pages
@@ -286,7 +284,7 @@ export default class PageDetails extends Component {
         if (page.uuid !== pageId) {
           this.setState({ page: { uuid: pageId, merged_into: page.uuid } });
         }
-        this._loadVersions(page, cutoffDate, '')
+        this._loadVersions(page)
           .then(versions => {
             page.versions = versions;
             this.setState({ page });
@@ -294,9 +292,11 @@ export default class PageDetails extends Component {
       });
   }
 
-  _loadVersions (page, dateFrom, dateTo) {
-    const capture_time = { 'capture_time': `${dateFrom}..${dateTo}` };
-    return this.context.api.getVersions(page.uuid, capture_time, Infinity);
+  _loadVersions (page) {
+    // TODO: This simply returns the sampled versions, but it might be nice to
+    // show how many versions were elided (`sample.version_count`).
+    return this.context.api.sampleVersions(page.uuid, Infinity)
+      .then(versions => versions.map(sample => sample.version));
   }
 
   _getChangeUrl (from, to, page) {

--- a/src/services/web-monitoring-db.js
+++ b/src/services/web-monitoring-db.js
@@ -211,7 +211,7 @@ export default class WebMonitoringDb {
    * lot of snapshots, like the EPA homepage.
    * @param {string} pageId
    * @param {number} limitChunks
-   * @returns {Promise<Version[]>}
+   * @returns {Promise<Array<{time: string, version_count: number, version: Version}>>}
    */
   sampleVersions (pageId, limitChunks = 1) {
     const url = this._createUrl(`pages/${pageId}/versions/sampled`);

--- a/src/services/web-monitoring-db.js
+++ b/src/services/web-monitoring-db.js
@@ -206,6 +206,19 @@ export default class WebMonitoringDb {
   }
 
   /**
+   * Get sample of versions (1 per day) for a given page. This is generally
+   * much faster and more efficient than `getVersions` for pages that have a
+   * lot of snapshots, like the EPA homepage.
+   * @param {string} pageId
+   * @param {number} limitChunks
+   * @returns {Promise<Version[]>}
+   */
+  sampleVersions (pageId, limitChunks = 1) {
+    const url = this._createUrl(`pages/${pageId}/versions/sampled`);
+    return this._getListChunks(url, parseVersionSample, limitChunks);
+  }
+
+  /**
    * Get list of versions for a given page.
    * @param {string} pageId
    * @param {string} query
@@ -458,6 +471,13 @@ function parseVersion (data) {
   }
 
   return result;
+}
+
+function parseVersionSample (data) {
+  return Object.assign({}, data, {
+    time: new Date(data.time),
+    version: parseVersion(data.version)
+  });
 }
 
 function parseAnnotation (data) {


### PR DESCRIPTION
In edgi-govdata-archiving/web-monitoring-db#946, we added a new API endpoint at `/api/v0/pages/:page_id/versions/sampled` that gets a "sampled" list of versions — that is, one version per sampling period (for now, the sampling period is always 1 day, so this is one version per day). This makes use of it.

The main idea here is to load data reasonably quickly — some pages (e.g. `https://epa.gov/`) have a *lot* of versions, and require hundreds of requests and many megabytes of data in order to load the details page. Loading a one-per-day sample makes pages much quicker to load, with fewer, smaller requests, but still giving people a complete-enough list of versions to select from.