### PR TITLE
Upgrade Node.js to v18.12.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: cimg/node:16.13.1
+      - image: cimg/node:18.12.1
     steps:
       - checkout
       - setup_npm
@@ -32,7 +32,7 @@ jobs:
 
   test:
     docker:
-      - image: cimg/node:16.13.1
+      - image: cimg/node:18.12.1
     steps:
       - checkout
       - setup_npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Baseline image for development/test/build ###
 # We require a lot of extras for building (Python, GCC) because of Node-Zopfli.
-FROM node:16.13.1 as dev
+FROM node:18.12.1 as dev
 LABEL maintainer="enviroDGI@gmail.com"
 
 RUN mkdir -p /app
@@ -30,7 +30,7 @@ RUN npm run build-production
 ### Release Image ###
 # It might feel ridiculous to build up all the same things again, but the
 # resulting image is less than half the size!
-FROM node:16.13.1-slim as release
+FROM node:18.12.1-slim as release
 LABEL maintainer="enviroDGI@gmail.com"
 
 RUN apt-get update && apt-get install -y --no-install-recommends dumb-init

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ It’s a React.js-based browser application with a Node.js backend with the foll
 
 ## Installation
 
-1. Install Node 16.13.1
-    - We recommend [installing Node Version Manager][nvm-install], then: `nvm install 16.13.1`
+1. Install Node 18.12.1
+    - We recommend [installing Node Version Manager][nvm-install], then: `nvm install 18.12.1`
     - If you are using Windows, check out [Nodenv][nodenv] or any of [these alternatives][nvm-alternatives].
 
 2. Install node dependencies with `npm`

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "webpack-dev-middleware": "^5.3.3"
       },
       "engines": {
-        "node": "16.13.1"
+        "node": "18.12.1"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "author": "",
   "license": "GPL-3.0",
   "engines": {
-    "node": "16.13.1"
+    "node": "18.12.1"
   },
   "browserslist": [
     "last 3 versions",


### PR DESCRIPTION
Node.js v18.x is now the LTS release, so we should update to it. This also comes with a bunch of security patches we should have applied from the 16.x line.