### PR TITLE
Don't require logging in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,9 @@ WEB_MONITORING_DB_URL=https://api.monitoring-staging.envirodatagov.org
 
 # Redirect all HTTP requests to https (you probably want this off in development)
 # FORCE_SSL=true
+
+# Don't force the user to log in before trying to browse. (Defaults to false)
+# Make sure this is aligned with the the API you are connecting to in
+# `WEB_MONITORING_DB_URL`! The API does not allow public users and you set this
+# to `true`, you're gonna have a bad time: most requests will result in errors.
+# ALLOW_PUBLIC_VIEW='true'

--- a/server/configuration.js
+++ b/server/configuration.js
@@ -1,11 +1,13 @@
 'use strict';
 
 const defaultValues = {
-  WEB_MONITORING_DB_URL: 'https://api.monitoring-staging.envirodatagov.org'
+  WEB_MONITORING_DB_URL: 'https://api.monitoring-staging.envirodatagov.org',
+  ALLOW_PUBLIC_VIEW: false
 };
 
 const clientFields = [
-  'WEB_MONITORING_DB_URL'
+  'WEB_MONITORING_DB_URL',
+  'ALLOW_PUBLIC_VIEW'
 ];
 
 const processEnvironment = Object.assign(
@@ -13,6 +15,17 @@ const processEnvironment = Object.assign(
   process.env,
   { NODE_ENV: (process.env.NODE_ENV || 'development').toLowerCase() }
 );
+
+function parseBoolean (text, options = { default: false }) {
+  if (text == null || text === '') return options.default;
+
+  if (typeof text === 'string') {
+    return /^t|true|1$/.test(text.trim().toLowerCase());
+  }
+  else {
+    return !!text;
+  }
+}
 
 /**
  * Get the current configuration for the app. This consists of the process's
@@ -41,6 +54,15 @@ function baseConfiguration () {
     else if (fromFile.parsed) {
       localEnvironment = Object.assign(fromFile.parsed, localEnvironment);
     }
+  }
+
+  // Special parsing
+  localEnvironment.ALLOW_PUBLIC_VIEW = parseBoolean(
+    localEnvironment.ALLOW_PUBLIC_VIEW,
+    { default: null }
+  );
+  if (localEnvironment.ALLOW_PUBLIC_VIEW == null) {
+    delete localEnvironment.ALLOW_PUBLIC_VIEW;
   }
 
   return Object.assign({}, defaultValues, localEnvironment);

--- a/src/components/change-view/change-view.jsx
+++ b/src/components/change-view/change-view.jsx
@@ -122,7 +122,7 @@ export default class ChangeView extends Component {
      * `canAnnotate` is arbitrary and DOES NOT reflect any intended permissions model or setup.
      * https://github.com/edgi-govdata-archiving/web-monitoring-ui/issues/120
      */
-    const userCanAnnotate = this.props.user.canAnnotate || null;
+    const userCanAnnotate = this.props.user?.canAnnotate || null;
     if (!page || !page.versions) {
       // if haz no page, don't render
       return (<div></div>);

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -132,10 +132,8 @@ export default class WebMonitoringUi extends Component {
       return <Loading />;
     }
 
-    /** TODO: When we move to a public platform, we might not
-     * need this check anymore because users should have
-     * some level of access without logging in.
-     */
+    // If logging in is required, don't bother rendering the requested route
+    // and *only* show the login dialog.
     if (!configuration.ALLOW_PUBLIC_VIEW && !this.state.user) {
       return this.renderLoginDialog();
     }

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -99,7 +99,7 @@ export default class WebMonitoringUi extends Component {
   loadPages () {
     api.isLoggedIn()
       .then(loggedIn => {
-        if (!loggedIn) {
+        if (!configuration.ALLOW_PUBLIC_VIEW && !loggedIn) {
           return Promise.reject(new Error('You must be logged in to view pages'));
         }
 
@@ -136,7 +136,7 @@ export default class WebMonitoringUi extends Component {
      * need this check anymore because users should have
      * some level of access without logging in.
      */
-    if (!this.state.user) {
+    if (!configuration.ALLOW_PUBLIC_VIEW && !this.state.user) {
       return this.renderLoginDialog();
     }
 


### PR DESCRIPTION
If the `ALLOW_PUBLIC_VIEW` config variable is set to `true`, the UI will no longer show a modal dialog requiring someone to be logged in before trying to browse any data. Having this work depends on the API actually allowing unauthenticated requests (at the time of writing, that's allowed in staging but not yet in production).

⚠️ **This might break in weird ways!** I need to do a once-over to make sure I covered all the obvious places we make assumptions about users, but it seems like we mostly did a good job not assuming anything. I will probably ship this just for staging pretty quickly, so I’m not marking it as a draft.

Fixes #1025.