### PR TITLE
Handle versions with no URL

### DIFF
--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -133,7 +133,9 @@ export function addTargetBlank (document) {
  */
 export function loadSubresourcesFromWayback (page, version) {
   return document => {
-    const url = versionUrl(version);
+    // In some rare instances, there is old, messy version data from Versionista
+    // that doesn't have a URL for the version, so fall back to page URL. :(
+    const url = versionUrl(version) || page.url;
     const timestamp = createWaybackTimestamp(version.capture_time);
     document.querySelectorAll('link[rel="stylesheet"]').forEach(node => {
       node.href = createWaybackUrl(node.getAttribute('href'), timestamp, url);


### PR DESCRIPTION
We should never encounter any versions with null URLs in production, but we do occasionally have some bad data in staging. This adds a fallback to deal with the situation. (Ideally, there'd be a test, but I'm not bothering since we guarantee there will be a URL in production.)

Fixes #1038.