### PR TITLE
Use correct name for media type "essence"

### DIFF
--- a/src/constants/diff-types.js
+++ b/src/constants/diff-types.js
@@ -87,8 +87,8 @@ export function diffTypesFor (mediaType) {
     type = parseMediaType(mediaType);
   }
 
-  return diffTypesByMediaType[type.mediaType]
+  return diffTypesByMediaType[type.essence]
     || diffTypesByMediaType[type.genericType]
-    || diffTypesByMediaType[unknownType.mediaType]
+    || diffTypesByMediaType[unknownType.essence]
     || [];
 }

--- a/src/scripts/__tests__/media-type.test.js
+++ b/src/scripts/__tests__/media-type.test.js
@@ -7,7 +7,7 @@ describe('MediaType module', () => {
     const type = MediaType('type', 'subtype');
     expect(type.type).toBe('type');
     expect(type.subtype).toBe('subtype');
-    expect(type.mediaType).toBe('type/subtype');
+    expect(type.essence).toBe('type/subtype');
     expect(type.genericType).toBe('type/*');
   });
 
@@ -15,7 +15,7 @@ describe('MediaType module', () => {
     const type = MediaType('type');
     expect(type.type).toBe('type');
     expect(type.subtype).toBe('*');
-    expect(type.mediaType).toBe('type/*');
+    expect(type.essence).toBe('type/*');
     expect(type.genericType).toBe('type/*');
   });
 
@@ -35,7 +35,7 @@ describe('MediaType module', () => {
     const type = parseMediaType('type/subtype');
     expect(type.type).toBe('type');
     expect(type.subtype).toBe('subtype');
-    expect(type.mediaType).toBe('type/subtype');
+    expect(type.essence).toBe('type/subtype');
     expect(type.genericType).toBe('type/*');
   });
 
@@ -53,12 +53,12 @@ describe('MediaType module', () => {
 
   test('parseMediaType should return a known canonical type if one matches the parsed type', () => {
     const type = parseMediaType('application/xhtml+xml');
-    expect(type.mediaType).toBe('text/html');
-    expect(type.exactType.mediaType).toBe('application/xhtml+xml');
+    expect(type.essence).toBe('text/html');
+    expect(type.exactType.essence).toBe('application/xhtml+xml');
   });
 
   test('parseMediaType should not return a canonical type if `canonicalize` is false', () => {
     const type = parseMediaType('application/xhtml+xml', false);
-    expect(type.mediaType).toBe('application/xhtml+xml');
+    expect(type.essence).toBe('application/xhtml+xml');
   });
 });

--- a/src/scripts/media-type.js
+++ b/src/scripts/media-type.js
@@ -17,11 +17,11 @@
  */
 export const unknownType = {
   genericType: '*/*',
-  mediaType: '*/*',
+  essence: '*/*',
   type: '*',
   subType: '*',
   equals (otherType) {
-    return !!otherType && this.mediaType === otherType.mediaType;
+    return !!otherType && this.essence === otherType.essence;
   }
 };
 
@@ -43,7 +43,7 @@ export default function MediaType (type, subtype) {
 
   return Object.assign(Object.create(unknownType), {
     genericType: `${type}/*`,
-    mediaType: `${type}/${subtype || '*'}`,
+    essence: `${type}/${subtype || '*'}`,
     type,
     subtype,
   });
@@ -98,7 +98,7 @@ export function parseMediaType (mediaType, canonicalize = true) {
   if (mediaType == null) {
     mediaType = '*/*';
   }
-  else if (mediaType.mediaType) {
+  else if (mediaType.essence) {
     return mediaType;
   }
   else if (!(typeof mediaType === 'string')) {
@@ -109,7 +109,7 @@ export function parseMediaType (mediaType, canonicalize = true) {
   let parsed = MediaType(parts[1], parts[2]);
 
   if (canonicalize) {
-    let canonicalType = canonicalTypes[parsed.mediaType];
+    let canonicalType = canonicalTypes[parsed.essence];
     if (canonicalType) {
       parsed = Object.create(canonicalType, { exactType: { value: parsed } });
     }


### PR DESCRIPTION
Back when I made our representation for media types, I was trying to figure out the right name of the `{type}/{subtype}` (without parameters) string form of the media type because I wasn't aware there *was* a correct name. I gave up and just called it `mediaType`. TIL it is properly referred to as the "essence": https://mimesniff.spec.whatwg.org/#understanding-mime-types