### PR TITLE
Handle content with lazy attributes on `<link>`

### DIFF
--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -138,7 +138,12 @@ export function loadSubresourcesFromWayback (page, version) {
     const url = versionUrl(version) || page.url;
     const timestamp = createWaybackTimestamp(version.capture_time);
     document.querySelectorAll('link[rel="stylesheet"]').forEach(node => {
-      node.href = createWaybackUrl(node.getAttribute('href'), timestamp, url);
+      for (const attribute of ['href', 'data-href']) {
+        const value = node.getAttribute(attribute);
+        if (value) {
+          node.setAttribute(attribute, createWaybackUrl(value, timestamp, url));
+        }
+      }
     });
     document.querySelectorAll('script[src],img[src]').forEach(node => {
       node.src = createWaybackUrl(node.getAttribute('src'), timestamp, url);


### PR DESCRIPTION
Some sites use a `data-href` attribute instead of `href` on `<link>` elements, and then have JavaScript lazily set the `href` attribute later in order to cause the link to load. We were naively assuming any `link` element would have an `href` attribute, and in these cases they do not. Fixes a crash on pages like https://monitoring.envirodatagov.org/page/4745c281-e4aa-4f31-bb15-147955845a52/a9690483-ecd0-4ee1-99c6-7de738385e55..26d3238f-0c09-480a-a04a-d41e3ddc0960.