### PR TITLE
Add detailed select labeling for network errors

### DIFF
--- a/src/components/select-version.jsx
+++ b/src/components/select-version.jsx
@@ -42,15 +42,19 @@ export default class SelectVersion extends PureComponent {
 
 function sourceLabel (version) {
   switch (version.source_type) {
-    case 'versionista':      return ' (Versionista)';
-    case 'internet_archive': return ' (Wayback)';
-    default:                 return '';
+    case 'versionista':         return ' (Versionista)';
+    case 'internet_archive':    return ' (Wayback)';
+    case 'edgi_statuscheck_v0': return ' (EDGI)';
+    default:                    return '';
   }
 }
 
 function statusLabel (version) {
   const status = version.status || 200;
-  if (status >= 400) {
+  if (version.network_error) {
+    return '✗ (Error) ';
+  }
+  else if (status >= 400) {
     return `✗ (${version.status} Error) `;
   }
   else if (version.content_length === 0) {


### PR DESCRIPTION
In edgi-govdata-archiving/web-monitoring-db#1184, we added the ability to show a nice error page when there are network-level errors and no valid HTTP response. This cleans up the labeling of those over here in the UI to make the a bit clearer.

So now that we have diffs like:

<img width="1487" alt="Screenshot 2025-02-02 at 11 48 14 PM" src="https://github.com/user-attachments/assets/dc8a30b6-4d04-4b20-a00b-9147a11f7499" />

The select box for these “network error” versions looks like:

<img width="444" alt="Screenshot 2025-02-02 at 11 49 05 PM" src="https://github.com/user-attachments/assets/51a57d91-4693-41d9-aef5-bca765577a95" />

This fixes it up to provide better info that this is an error (not just no content) and the source of the data:

<img width="437" alt="Screenshot 2025-02-02 at 11 48 52 PM" src="https://github.com/user-attachments/assets/54742438-2b81-447e-a3a8-67e4af31ed89" />