### PR TITLE
Label versions from new EDGI crawls as "EDGI"

### DIFF
--- a/src/components/select-version.jsx
+++ b/src/components/select-version.jsx
@@ -45,6 +45,7 @@ function sourceLabel (version) {
     case 'versionista':         return ' (Versionista)';
     case 'internet_archive':    return ' (Wayback)';
     case 'edgi_statuscheck_v0': return ' (EDGI)';
+    case 'edgi_crawl_v0':       return ' (EDGI)';
     default:                    return '';
   }
 }


### PR DESCRIPTION
We've started doing a handful of our own crawls, so the data from them needs to be labeled appropriately. Pretty minor!