### PR TITLE
Ensure we always show the versions in the URL

### DIFF
--- a/src/__mocks__/simple-page.json
+++ b/src/__mocks__/simple-page.json
@@ -71,6 +71,29 @@
       "created_at": "2017-05-02T23:55:57.033Z",
       "updated_at": "2017-05-02T23:55:57.033Z",
       "title": "Earth Science Conference Convenes | National Centers for Environmental Information (NCEI)"
+    },
+    {
+      "uuid": "70aa8b7b-d485-48dc-8295-7635ff04dc5c",
+      "page_uuid": "9420d91c-2fd8-411a-a756-5bf976574d10",
+      "url": "http://www.ncei.noaa.gov/news/earth-science-conference-convenes",
+      "capture_time": "2017-01-17T10:00:00.000Z",
+      "body_url": "https://edgi-wm-versionista.s3.amazonaws.com/versionista2/74303-6222064/version-9437401.html",
+      "body_hash": "03942355429ebd4bf526199777879fdf069a23ec040a9517b556df8aa4d1a8d3",
+      "media_type": null,
+      "media_type_parameters": null,
+      "content_length": 31190,
+      "source_type": "versionista",
+      "source_metadata": {
+        "url": "https://versionista.com/74303/6222064/9437400/",
+        "account": "versionista2",
+        "page_id": "6222064",
+        "site_id": "74303",
+        "version_id": "9437400",
+        "has_content": true
+      },
+      "created_at": "2017-05-02T23:55:57.033Z",
+      "updated_at": "2017-05-02T23:55:57.033Z",
+      "title": "Earth Science Conference Convenes | National Centers for Environmental Information (NCEI)"
     }
   ],
   "maintainers": [

--- a/src/components/__tests__/page-details.test.jsx
+++ b/src/components/__tests__/page-details.test.jsx
@@ -29,7 +29,10 @@ describe('page-details', () => {
     samples = Object.values(samples).sort((a, b) => a.time < b.time ? 1 : -1);
 
     return Object.assign(Object.create(WebMonitoringDb.prototype), {
-      getPage: jest.fn().mockResolvedValue(simplePage),
+      getPage: jest.fn().mockResolvedValue({ ...simplePage }),
+      getVersion: jest.fn(id => Promise.resolve(
+        simplePage.versions.find(v => v.uuid === id)
+      )),
       getVersions: jest.fn().mockResolvedValue(simplePage.versions),
       sampleVersions: jest.fn().mockResolvedValue(samples)
     });
@@ -58,14 +61,40 @@ describe('page-details', () => {
       { context: { api: mockApi } }
     );
 
-    // Wait for mock APIs to have been called.
-    await mockApi.getPage.mock.results[0].value;
-    await mockApi.sampleVersions.mock.results[0].value;
     await timers.setTimeout(10);
+    expect(mockApi.getPage).toHaveBeenCalled();
+    expect(mockApi.sampleVersions).toHaveBeenCalled();
 
     expect(document.title).toBe('Scanner | http://www.ncei.noaa.gov/news/earth-science-conference-convenes');
 
     pageDetails.unmount();
     expect(document.title).toBe('Scanner');
+  });
+
+  it('gets versions missing from the sample', async () => {
+    const allVersions = simplePage.versions;
+    const mockApi = createMockApi();
+    const pageDetails = shallow(
+      <PageDetails
+        match={{
+          ...match,
+          params: {
+            ...match.params,
+            change: `${allVersions.at(-1).uuid}..${allVersions[0].uuid}`
+          }
+        }}
+      />,
+      { context: { api: mockApi } }
+    );
+
+    await timers.setTimeout(10);
+    expect(mockApi.getPage).toHaveBeenCalled();
+    expect(mockApi.sampleVersions).toHaveBeenCalled();
+    expect(mockApi.getVersion).toHaveBeenCalled();
+
+    // expect(document.title).toBe('Scanner | http://www.ncei.noaa.gov/news/earth-science-conference-convenes');
+    expect(pageDetails.exists()).toEqual(true);
+    // It should always have rendered *something.*
+    expect(pageDetails.get(0)).toBeTruthy();
   });
 });

--- a/src/services/web-monitoring-db.js
+++ b/src/services/web-monitoring-db.js
@@ -236,7 +236,8 @@ export default class WebMonitoringDb {
    * @returns {Promise<Version>}
    */
   getVersion (versionId) {
-    return this._request(this._createUrl(`versions/${versionId}`))
+    const url = this._createUrl(`versions/${versionId}`, { different: false });
+    return this._request(url)
       .then(response => response.json())
       .then(throwIfError(`Could not load version: ${versionId}`))
       .then(data => parseVersion(data.data));


### PR DESCRIPTION
Way back when we added version sampling to speed things up and reduce overhead, it came with the downside that some links from our our task sheets wouldn't always display as expected, because they might not include one of the sampled versions. They would then wind up displaying a different change. This has become a much bigger issue recently, where we have a lot of spurious, possibly bad captures from various sources (mostly Wayback), and the cost of switching to a different version may be displaying something drastically different.

This solves the issue by explicitly loading the expected versions and merging them into the sample if they aren’t found after the samples are loaded. It’s a bit of a quick fix — I think version history loading needs some bigger reform (they need to not block display of the diff!), but it works well for now.