### PR TITLE
Sync scrolling in side-by-side diff

### DIFF
--- a/src/components/change-view/change-view.jsx
+++ b/src/components/change-view/change-view.jsx
@@ -418,6 +418,7 @@ function loadDiffSettings () {
   return layeredStorage.getItem(diffSettingsStorage) || {
     removeFormatting: false,
     useWaybackResources: true,
+    syncScrolling: true,
   };
 }
 

--- a/src/components/diff-settings-form.jsx
+++ b/src/components/diff-settings-form.jsx
@@ -54,7 +54,28 @@ export default class DiffSettingsForm extends PureComponent {
           </input>
           Load Resources from Wayback Machine
         </label>
+
+        {this._renderSideBySideSettings()}
       </form>
+    );
+  }
+
+  _renderSideBySideSettings () {
+    if (this.props.diffType !== 'SIDE_BY_SIDE_RENDERED') {
+      return null;
+    }
+
+    return (
+      <label className="utilities__label">
+        <input
+          checked={this.props.settings.syncScrolling}
+          className="utilities__input"
+          name="syncScrolling"
+          onChange={this._handleCheckboxChange}
+          type="checkbox">
+        </input>
+        Sync Scrolling
+      </label>
     );
   }
 

--- a/src/components/diff-view.jsx
+++ b/src/components/diff-view.jsx
@@ -152,7 +152,8 @@ export default class DiffView extends Component {
         return (
           <SideBySideRenderedDiff {...commonProps}
             removeFormatting={this.props.diffSettings.removeFormatting}
-            useWaybackResources={this.props.diffSettings.useWaybackResources} />
+            useWaybackResources={this.props.diffSettings.useWaybackResources}
+            syncScrolling={this.props.diffSettings.syncScrolling} />
         );
       case diffTypes.OUTGOING_LINKS.value:
         return (

--- a/src/components/sandboxed-html.jsx
+++ b/src/components/sandboxed-html.jsx
@@ -37,6 +37,21 @@ export default class SandboxedHtml extends PureComponent {
     />;
   }
 
+  /**
+   * Use the `window.postMessage()` API to send a message to the JS code
+   * running in this SandboxedHtml view. To use this, you'll need to keep a ref
+   * to this component.
+   * @param {any} message
+   */
+  postMessage (message) {
+    if (this._frame) {
+      this._frame.contentWindow.postMessage(message, '*');
+    }
+    else {
+      console.warn('Tried to post message with no reference to `_frame`');
+    }
+  }
+
   _updateContent () {
     let source = transformSource(this.props.html, document => {
       if (this.props.transform) {

--- a/src/components/side-by-side-rendered-diff.jsx
+++ b/src/components/side-by-side-rendered-diff.jsx
@@ -84,16 +84,16 @@ export default class SideBySideRenderedDiff extends Component {
   }
 
   /**
-   * Broker scroll events between the two pages. When one page scrolls, it will
-   * post a message with scroll info. We basically just forward that to the
+   * Handle `message` events sent to this window via `postMessage()`.
+   *
+   * This brokers scroll events between the two pages. When one page scrolls,
+   * it will post a message with scroll position info. We forward that to the
    * other page so it can update its scroll position to match.
    * @param {MessageEvent} event
    */
   _receiveWindowMessage (event) {
-    if (!this.props.syncScrolling) return;
-    if (event.data.type !== '__wm_scroll') return;
+    if (!this.props.syncScrolling || event.data.type !== '__wm_scroll') return;
 
-    console.log('Scroll update:', event.data);
     const target = event.data.from === 'A' ? this._htmlViewB : this._htmlViewA;
     if (target) {
       target.postMessage({
@@ -102,7 +102,9 @@ export default class SideBySideRenderedDiff extends Component {
       });
     }
     else {
-      console.error('Could not find target SandboxedHtml to send scroll command to.');
+      console.error(
+        'Could not find target SandboxedHtml to forward scroll command to!'
+      );
     }
   }
 }

--- a/src/components/side-by-side-rendered-diff.jsx
+++ b/src/components/side-by-side-rendered-diff.jsx
@@ -3,6 +3,7 @@ import {
   removeStyleAndScript,
   removeClientRedirect,
   loadSubresourcesFromWayback,
+  managedScrolling,
   compose,
   addTargetBlank
 } from '../scripts/html-transforms';
@@ -17,6 +18,7 @@ import SandboxedHtml from './sandboxed-html';
  * @property {Version} b The "B" version of the page this diff pertains to
  * @property {boolean} removeFormatting
  * @property {boolean} useWaybackResources
+ * @property {boolean} syncScrolling
  */
 
 /**
@@ -27,6 +29,21 @@ import SandboxedHtml from './sandboxed-html';
  * @param {SideBySideRenderedDiffProps} props
  */
 export default class SideBySideRenderedDiff extends Component {
+  constructor (props) {
+    super(props);
+    this._receiveWindowMessage = this._receiveWindowMessage.bind(this);
+    this._htmlViewA = null;
+    this._htmlViewB = null;
+  }
+
+  componentDidMount () {
+    window.addEventListener('message', this._receiveWindowMessage);
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('message', this._receiveWindowMessage);
+  }
+
   render () {
     const baseTransform = compose(
       this.props.removeFormatting && removeStyleAndScript,
@@ -35,6 +52,8 @@ export default class SideBySideRenderedDiff extends Component {
     );
     let transformA = baseTransform;
     let transformB = baseTransform;
+    transformA = compose(transformA, managedScrolling('A'));
+    transformB = compose(transformB, managedScrolling('B'));
     if (this.props.useWaybackResources) {
       transformA = compose(transformA, loadSubresourcesFromWayback(
         this.props.page,
@@ -52,13 +71,38 @@ export default class SideBySideRenderedDiff extends Component {
           html={this.props.diffData.deletions}
           baseUrl={versionUrl(this.props.a)}
           transform={transformA}
+          ref={node => this._htmlViewA = node}
         />
         <SandboxedHtml
           html={this.props.diffData.insertions}
           baseUrl={versionUrl(this.props.b)}
           transform={transformB}
+          ref={node => this._htmlViewB = node}
         />
       </div>
     );
+  }
+
+  /**
+   * Broker scroll events between the two pages. When one page scrolls, it will
+   * post a message with scroll info. We basically just forward that to the
+   * other page so it can update its scroll position to match.
+   * @param {MessageEvent} event
+   */
+  _receiveWindowMessage (event) {
+    if (!this.props.syncScrolling) return;
+    if (event.data.type !== '__wm_scroll') return;
+
+    console.log('Scroll update:', event.data);
+    const target = event.data.from === 'A' ? this._htmlViewB : this._htmlViewA;
+    if (target) {
+      target.postMessage({
+        ...event.data,
+        type: '__wm_scroll_to',
+      });
+    }
+    else {
+      console.error('Could not find target SandboxedHtml to send scroll command to.');
+    }
   }
 }

--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -156,8 +156,247 @@ export function loadSubresourcesFromWayback (page, version) {
   };
 }
 
+export function managedScrolling (identifier) {
+  const origin = window.origin;
+  return (document) => {
+    markScrollLandmarks(document);
+
+    if (!document.head) {
+      const head = document.createElement('head');
+      const firstChild = document.documentElement.firstChild;
+      if (firstChild) {
+        document.documentElement.insertBefore(head, firstChild);
+      }
+      else {
+        document.documentElement.appendChild(head);
+      }
+    }
+
+    const script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.innerHTML = `(${inPageScrollModule})('${identifier}', '${origin}');`;
+    document.head.appendChild(script);
+    return document;
+  };
+}
 
 // ---------------------- Support Functions -----------------------------
+
+/**
+ * Find elements that are usable as scrolling landmarks and mark them in the
+ * DOM as such. When syncing scrolling in side-by-side views, we use these
+ * landmarks to denote the scroll postion (landmark X, offset to landmark X+1).
+ * This lets synced scrolling keep related parts of the page side-by-side even
+ * when big changes one side have altered their locations.
+ *
+ * When the pages are live, `inPageScrollModule` (inserted into the pages
+ * themselves) finds these landmarks and their positions on screen.
+ *
+ * TODO: Ideally we'd use the changes themselves as landmarks and not need this,
+ * but the differ needs to be changed to output placeholders for the insertions
+ * on the deletions side (and vice-versa), since a usable landmark has to be
+ * present in both views we are syncing.
+ *
+ * @param {Document} document
+ */
+function markScrollLandmarks (document) {
+  const candidates = [...document.querySelectorAll('h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6')];
+  let index = 0;
+  for (const e of candidates) {
+    const noChanges = !e.querySelector('.wm-diff') && !e.matches(':is(.wm-diff *)');
+    const text = e.textContent.trim().replace(/[\s\n]+/, '');
+
+    if (noChanges && text) {
+      // This element should be present in some form on both sides, and is
+      // usable as a landmark.
+      e.classList.add('wm-scroll-landmark');
+      e.setAttribute('wm-scroll-landmark', index);
+      index++;
+    }
+  }
+}
+
+function inPageScrollModule (identifier, appOrigin) {
+  // Tracks whether we are currently setting the scroll position. If true, then
+  // we can ignore scroll events.
+  let __wm_autoScrolling = false;
+  let __wm_scrollLandmarks = [];
+
+  window.addEventListener('scroll', (e) => {
+    //console.log('SCROLL EVENT in frame ${identifier}, auto:', __wm_autoScrolling, e);
+    if (__wm_autoScrolling) {
+      __wm_autoScrolling = false;
+      return;
+    }
+
+    let anchorText = '<start>';
+    let nextText = '<end>';
+    const y = window.scrollY;
+    let anchorY = 0;
+    let nextY = window.scrollMaxY;
+    let landmarkId = -1;
+    let nextLandmark = __wm_scrollLandmarks.find(l => l.y > y && l.usable);
+    if (nextLandmark) {
+      nextY = nextLandmark.y;
+      nextText = nextLandmark.text;
+      for (let i = nextLandmark.id - 1; i >= 0; i--) {
+        const landmark = __wm_scrollLandmarks[i];
+        if (landmark.usable) {
+          landmarkId = landmark.id;
+          anchorY = landmark.y;
+          anchorText = landmark.text;
+          break;
+        }
+      }
+      // if (nextLandmark.id > 0) {
+      //   const landmark = __wm_scrollLandmarks[nextLandmark.id - 1];
+      //   landmarkId = landmark.id;
+      //   anchorY = landmark.y;
+      //   anchorText = landmark.text;
+      // }
+    }
+    else if (__wm_scrollLandmarks.length) {
+      for (let i = __wm_scrollLandmarks.length - 1; i >= 0; i--) {
+        const landmark = __wm_scrollLandmarks[i];
+        if (landmark.usable) {
+          landmarkId = landmark.id;
+          anchorY = landmark.y;
+          anchorText = landmark.text;
+          break;
+        }
+      }
+      // const landmark = __wm_scrollLandmarks.at(-1);
+      // landmarkId = landmark.id;
+      // anchorY = landmark.y;
+      // anchorText = landmark.text;
+    }
+
+    console.log(`SCROLL CALC: anchorY=${anchorY}, y=${y}, nextY=${nextY} (anchor: "${anchorText}", next: "${nextText}")`, __wm_scrollLandmarks);
+
+    window.top.postMessage({
+      from: identifier,
+      type: '__wm_scroll',
+      position: { x: window.scrollX, y: window.scrollY },
+      landmark: landmarkId,
+      offset: (y - anchorY) / (nextY - anchorY)
+    }, appOrigin);
+  });
+
+  window.addEventListener('message', (event) => {
+    if (event.data.type === '__wm_scroll_to') {
+      updateScrollLandmarks();
+      //console.log('RECEIVED scroll command in ${identifier}');
+      let x = event.data.position.x;
+      let y = event.data.position.y;
+
+      let useLandmarks = true;
+      let anchorY = 0;
+      if (event.data.landmark > -1) {
+        const landmark = __wm_scrollLandmarks[event.data.landmark];
+        if (landmark) {
+          anchorY = landmark.y;
+        }
+        else {
+          useLandmarks = false;
+          console.warn(`Could not find scroll landmark in ${identifier}, falling back to literal position`);
+        }
+      }
+      if (useLandmarks) {
+        let nextY = window.scrollMaxY;
+        for (let i = event.data.landmark + 1; i < __wm_scrollLandmarks.length; i++) {
+          const nextLandmark = __wm_scrollLandmarks[i];
+          if (nextLandmark.usable) {
+            nextY = nextLandmark.y;
+            break;
+          }
+        }
+        y = anchorY + event.data.offset * (nextY - anchorY);
+        // const nextLandmark = __wm_scrollLandmarks[event.data.landmark + 1];
+        // const nextY = nextLandmark?.y ?? window.scrollMaxY;
+        // y = anchorY + event.data.offset * (nextY - anchorY);
+      }
+
+      __wm_autoScrolling = true;
+      window.scrollTo({ left: x, top: y, behavior: 'instant' });
+    }
+  });
+
+  function getScrollLandmarks () {
+    // const rootBounds = document.documentElement.getBoundingClientRect();
+    const baseX = window.scrollX;
+    const baseY = window.scrollY;
+    const result = Array.from(document.querySelectorAll('[wm-scroll-landmark]'))
+      .map(node => {
+        const id = parseInt(node.getAttribute('wm-scroll-landmark'), 10);
+        if (isNaN(id)) return null;
+
+        const bounds = node.getBoundingClientRect();
+        const x = bounds.left + baseX;
+        const y = bounds.top + baseY;
+        const usable = (
+          bounds.width > 0
+          && bounds.height > 0
+          && x + bounds.width > 0
+          && y + bounds.height > 0
+        );
+
+        return {
+          id,
+          // x: bounds.left - rootBounds.left,
+          // y: bounds.top - rootBounds.top,
+          // x: bounds.left + baseX,
+          // y: bounds.top + baseY,
+          x,
+          y,
+          usable,
+          text: node.textContent.trim().replace(/[\s\n]+/g, ' '),
+        };
+      })
+      .filter(Boolean);
+    // result.push()
+    if (result.some((x, index) => x.id !== index)) {
+      console.error(`SCROLL LANDMARK IDS OUT OF SYNC in ${identifier}:`, result);
+    }
+    return result;
+  }
+
+  let lastUpdate = 0;
+  let updateTimer = null;
+  function updateScrollLandmarks () {
+    clearTimeout(updateTimer);
+    const now = Date.now();
+    if (now - lastUpdate < 1000) {
+      updateTimer = setTimeout(updateScrollLandmarks, 1000 - (now - lastUpdate));
+      return;
+    }
+    lastUpdate = now;
+    console.log(`Scroll landmakr update in ${identifier}`);
+    __wm_scrollLandmarks = getScrollLandmarks();
+    // window.top.postMessage({
+    //   from: identifier,
+    //   type: '__wm_scroll_landmarks',
+    //   landmarks: getScrollLandmarks()
+    // });
+  }
+
+  // TODO: update and send landmarks at appropriate times:
+  // - immediately
+  // - on DOM mutation
+  // - after load/error events
+  // - after page load
+
+  updateScrollLandmarks();
+  window.addEventListener('load', updateScrollLandmarks);
+  document.addEventListener('load', updateScrollLandmarks, true);
+  // document.addEventListener('error', updateScrollLandmarks, true);
+  document.addEventListener('DOMContentLoaded', updateScrollLandmarks);
+  // document.addEventListener('DOMContentLoaded', () => {
+  //   setInterval(updateScrollLandmarks, 10000);
+  //   // const observer = new MutationObserver(updateScrollLandmarks);
+  //   // observer.observe(document.body, { subtree: true, childList: true, attributes: true });
+  // });
+
+}
 
 /**
  * Convert a Date object to to a Wayback-Machine style timestamp string.

--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -410,6 +410,7 @@ function inPageScrollModule (identifier, appOrigin) {
 
   updateScrollLandmarks();
   window.addEventListener('load', updateScrollLandmarks);
+  window.addEventListener('resize', updateScrollLandmarks);
   document.addEventListener('load', updateScrollLandmarks, true);
   // document.addEventListener('error', updateScrollLandmarks, true);
   document.addEventListener('DOMContentLoaded', updateScrollLandmarks);


### PR DESCRIPTION
A *long* overdue issue in the side-by-side diff view is that scrolling isn’t sync'd, so you need to manually scroll each view to be able to compare what’s happening an you move down the page. This finally adds support.

This is a little complicated for a few reasons:

First, the two side-by-side views have a different origin than the main app, posing security issues. To solve this, we use the `postMessage` API:
1. We inject a script into each view that listens for `scroll` and `message` events.
2. When one page receives a `scroll` event, it packages it up and posts a message about its new scroll position to the parent window (the main app).
3. Then the app forwards that to the other page (using `window.postMessage()`).
4. The other page receives that `message` event and updates its scroll position to match.

Second, large insertions or deletions often cause matching parts of the page to be in different places on either side of the diff. For sync'd scrolling to be useful, we need to keep relevant parts of the page together. To handle this, we have a concept of “landmarks” — parts of the page that are present on both sides and should line up visually when scrolling. Then we keep track of scroll positions in terms of a landmark and an offset (actually a % distance between the landmark and the next landmark) instead of an absolute pixel position. Each side of the diff keeps track of where its landmarks are on screen so when it updates its scroll position, it keeps landmarks visually side-by-side.

*Ideally*, the differ would output placeholders for insertions on the deletion side, and vice-versa, so the changes themselves would be landmarks. It doesn’t do that right now, so instead we look for unchanged headings and other major elements to serve as landmarks.

This first pass is pretty messy, but seems to work alright. I need to clean up all the logging, and then I think this OK to land for analysts to get some use out of it.