### PR TITLE
Don't re-render diff when changing scroll sync

### DIFF
--- a/src/components/sandboxed-html.jsx
+++ b/src/components/sandboxed-html.jsx
@@ -60,7 +60,9 @@ export default class SandboxedHtml extends PureComponent {
       return setDocumentBase(document, this.props.baseUrl);
     });
 
-    this._frame.setAttribute('srcdoc', source);
+    if (source !== this._frame.getAttribute('srcdoc')) {
+      this._frame.setAttribute('srcdoc', source);
+    }
   }
 }
 


### PR DESCRIPTION
When toggling whether scrolling was sync'd, the diff views used to re-render and reset their scrolling to the top (so you couldn't, for example, scroll to a position, unsync, and then scroll more on one side). This was happening because changing the setting (re-)creates a new set of transforms, which are different props for the `SandboxedHtmlView`, which then re-sets the `srcdoc` property on its `iframe`. This solves the issue by only re-setting `srcdoc` if we are actually changing it.

Ideally we'd also do some caching of transforms so that creating one with the same arguments returns an identical transformer function, but that's a whole other ball of wax with memory management, and is not the only way we can cause this sort of problem. This fix is dumber, but probably more resilient.