### PR TITLE
Remove react-dates, use Luxon for time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "body-parser": "^2.2.0",
         "ejs": "^3.1.10",
         "express": "^5.1.0",
+        "luxon": "^3.6.1",
         "normalize.css": "^8.0.1"
       },
       "devDependencies": {
@@ -37,8 +38,6 @@
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0",
         "mini-css-extract-plugin": "^2.9.2",
-        "moment": "^2.30.1",
-        "moment-locales-webpack-plugin": "^1.2.0",
         "postcss": "^8.5.6",
         "postcss-loader": "^8.1.1",
         "react": "^16.14.0",
@@ -10890,12 +10889,6 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
     },
-    "node_modules/lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -10924,6 +10917,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {
@@ -11123,28 +11125,6 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-locales-webpack-plugin": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz",
-      "integrity": "sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash.difference": "^4.5.0"
-      },
-      "peerDependencies": {
-        "moment": "^2.8.0",
-        "webpack": "^1 || ^2 || ^3 || ^4 || ^5"
       }
     },
     "node_modules/mrmime": {
@@ -22205,12 +22185,6 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
     },
-    "lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -22234,6 +22208,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ=="
     },
     "lz-string": {
       "version": "1.5.0",
@@ -22368,21 +22347,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true
-    },
-    "moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "dev": true
-    },
-    "moment-locales-webpack-plugin": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz",
-      "integrity": "sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==",
-      "dev": true,
-      "requires": {
-        "lodash.difference": "^4.5.0"
-      }
     },
     "mrmime": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "postcss-loader": "^8.1.1",
         "react": "^16.14.0",
         "react-aria-modal": "^5.0.2",
-        "react-dates": "^21.8.0",
         "react-dom": "^16.14.0",
         "react-router-dom": "^5.3.0",
         "react-tooltip": "^5.29.1",
@@ -4489,29 +4488,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/airbnb-prop-types": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
-      "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
-      "dev": true,
-      "dependencies": {
-        "array.prototype.find": "^2.1.1",
-        "function.prototype.name": "^1.1.2",
-        "is-regex": "^1.1.0",
-        "object-is": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.13.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "react": "^0.14 || ^15.0.0 || ^16.0.0-alpha"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4668,19 +4644,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.find": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
-      "integrity": "sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==",
-      "dev": true,
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/array.prototype.findlast": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
@@ -4693,23 +4656,6 @@
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
         "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flat": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
-      "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5174,12 +5120,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/brcast": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
-      "integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg==",
-      "dev": true
-    },
     "node_modules/browserslist": {
       "version": "4.25.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
@@ -5572,12 +5512,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "node_modules/consolidated-events": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
-      "integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ==",
-      "dev": true
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -6134,19 +6068,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/direction": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
-      "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
-      "dev": true,
-      "bin": {
-        "direction": "cli.js"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -6157,18 +6078,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/document.contains": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.2.tgz",
-      "integrity": "sha512-YcvYFs15mX8m3AO1QNQy3BlIpSMfNRj3Ujk2BEJxsZG+HZf7/hZ6jr7mDpXrF8q+ff95Vef5yjhiZxm8CGJr6Q==",
-      "dev": true,
-      "dependencies": {
-        "define-properties": "^1.1.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -6318,19 +6227,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/enzyme-shallow-equal": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.5.tgz",
-      "integrity": "sha512-i6cwm7hN630JXenxxJFBKzgLC3hMTafFQXflvzHgPmDhOBhxUWDe8AeRv1qp2/uWJ2Y8z5yLWMzmAfkTOiOCZg==",
-      "dev": true,
-      "dependencies": {
-        "has": "^1.0.3",
-        "object-is": "^1.1.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/error-ex": {
@@ -7789,19 +7685,6 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
-    "node_modules/global-cache": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/global-cache/-/global-cache-1.2.1.tgz",
-      "integrity": "sha512-EOeUaup5DgWKlCMhA9YFqNRIlZwoxt731jCh47WBV9fQqHgXhr3Fa55hfgIUqilIcPsfdNKN7LHjrNY+Km40KA==",
-      "dev": true,
-      "dependencies": {
-        "define-properties": "^1.1.2",
-        "is-symbol": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -7916,18 +7799,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/has-bigints": {
@@ -8645,12 +8516,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-touch-device": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-touch-device/-/is-touch-device-1.0.1.tgz",
-      "integrity": "sha512-LAYzo9kMT1b2p19L/1ATGt2XcSilnzNlyvq6c0pbPRVisLbAPpLqr53tIJS00kvrTkj0HtR8U7+u8X0yR8lPSw==",
-      "dev": true
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
@@ -11812,12 +11677,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -12013,17 +11872,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/prop-types-exact": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
-      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
-      "dev": true,
-      "dependencies": {
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "reflect.ownkeys": "^0.2.0"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -12102,15 +11950,6 @@
         }
       ]
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -12171,36 +12010,6 @@
         "react-dom": ">=16.3.0"
       }
     },
-    "node_modules/react-dates": {
-      "version": "21.8.0",
-      "resolved": "https://registry.npmjs.org/react-dates/-/react-dates-21.8.0.tgz",
-      "integrity": "sha512-PPriGqi30CtzZmoHiGdhlA++YPYPYGCZrhydYmXXQ6RAvAsaONcPtYgXRTLozIOrsQ5mSo40+DiA5eOFHnZ6xw==",
-      "dev": true,
-      "dependencies": {
-        "airbnb-prop-types": "^2.15.0",
-        "consolidated-events": "^1.1.1 || ^2.0.0",
-        "enzyme-shallow-equal": "^1.0.0",
-        "is-touch-device": "^1.0.1",
-        "lodash": "^4.1.1",
-        "object.assign": "^4.1.0",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.2",
-        "raf": "^3.4.1",
-        "react-moment-proptypes": "^1.6.0",
-        "react-outside-click-handler": "^1.2.4",
-        "react-portal": "^4.2.0",
-        "react-with-direction": "^1.3.1",
-        "react-with-styles": "^4.1.0",
-        "react-with-styles-interface-css": "^6.0.0"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.0.0",
-        "moment": "^2.18.1",
-        "react": "^0.14 || ^15.5.4 || ^16.1.1",
-        "react-dom": "^0.14 || ^15.5.4 || ^16.1.1",
-        "react-with-direction": "^1.3.1"
-      }
-    },
     "node_modules/react-dom": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
@@ -12221,47 +12030,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "node_modules/react-moment-proptypes": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.8.1.tgz",
-      "integrity": "sha512-Er940DxWoObfIqPrZNfwXKugjxMIuk1LAuEzn23gytzV6hKS/sw108wibi9QubfMN4h+nrlje8eUCSbQRJo2fQ==",
-      "dev": true,
-      "dependencies": {
-        "moment": ">=1.6.0"
-      },
-      "peerDependencies": {
-        "moment": ">=1.6.0"
-      }
-    },
-    "node_modules/react-outside-click-handler": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz",
-      "integrity": "sha512-Te/7zFU0oHpAnctl//pP3hEAeobfeHMyygHB8MnjP6sX5OR8KHT1G3jmLsV3U9RnIYo+Yn+peJYWu+D5tUS8qQ==",
-      "dev": true,
-      "dependencies": {
-        "airbnb-prop-types": "^2.15.0",
-        "consolidated-events": "^1.1.1 || ^2.0.0",
-        "document.contains": "^1.0.1",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^0.14 || >=15",
-        "react-dom": "^0.14 || >=15"
-      }
-    },
-    "node_modules/react-portal": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.1.tgz",
-      "integrity": "sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==",
-      "dev": true,
-      "dependencies": {
-        "prop-types": "^15.5.8"
-      },
-      "peerDependencies": {
-        "react": "^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0"
-      }
     },
     "node_modules/react-router-dom": {
       "version": "5.3.0",
@@ -12339,67 +12107,6 @@
       "peerDependencies": {
         "react": ">=16.14.0",
         "react-dom": ">=16.14.0"
-      }
-    },
-    "node_modules/react-with-direction": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.4.0.tgz",
-      "integrity": "sha512-ybHNPiAmaJpoWwugwqry9Hd1Irl2hnNXlo/2SXQBwbLn/jGMauMS2y9jw+ydyX5V9ICryCqObNSthNt5R94xpg==",
-      "dev": true,
-      "dependencies": {
-        "airbnb-prop-types": "^2.16.0",
-        "brcast": "^2.0.2",
-        "deepmerge": "^1.5.2",
-        "direction": "^1.0.4",
-        "hoist-non-react-statics": "^3.3.2",
-        "object.assign": "^4.1.2",
-        "object.values": "^1.1.5",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^0.14 || ^15 || ^16",
-        "react-dom": "^0.14 || ^15 || ^16"
-      }
-    },
-    "node_modules/react-with-direction/node_modules/deepmerge": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
-      "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-with-styles": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-4.2.0.tgz",
-      "integrity": "sha512-tZCTY27KriRNhwHIbg1NkSdTTOSfXDg6Z7s+Q37mtz0Ym7Sc7IOr3PzVt4qJhJMW6Nkvfi3g34FuhtiGAJCBQA==",
-      "dev": true,
-      "dependencies": {
-        "airbnb-prop-types": "^2.14.0",
-        "hoist-non-react-statics": "^3.2.1",
-        "object.assign": "^4.1.0",
-        "prop-types": "^15.7.2",
-        "react-with-direction": "^1.3.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.0.0",
-        "react": ">=0.14",
-        "react-with-direction": "^1.3.1"
-      }
-    },
-    "node_modules/react-with-styles-interface-css": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-6.0.0.tgz",
-      "integrity": "sha512-6khSG1Trf4L/uXOge/ZAlBnq2O2PEXlQEqAhCRbvzaQU4sksIkdwpCPEl6d+DtP3+IdhyffTWuHDO9lhe1iYvA==",
-      "dev": true,
-      "dependencies": {
-        "array.prototype.flat": "^1.2.1",
-        "global-cache": "^1.2.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.0.0",
-        "react-with-styles": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/read-pkg": {
@@ -12498,12 +12205,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/reflect.ownkeys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
-      "dev": true
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -17945,23 +17646,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="
     },
-    "airbnb-prop-types": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
-      "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
-      "dev": true,
-      "requires": {
-        "array.prototype.find": "^2.1.1",
-        "function.prototype.name": "^1.1.2",
-        "is-regex": "^1.1.0",
-        "object-is": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.13.1"
-      }
-    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -18080,16 +17764,6 @@
         "math-intrinsics": "^1.1.0"
       }
     },
-    "array.prototype.find": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
-      "integrity": "sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.4"
-      }
-    },
     "array.prototype.findlast": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
@@ -18102,17 +17776,6 @@
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
         "es-shim-unscopables": "^1.0.2"
-      }
-    },
-    "array.prototype.flat": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
-      "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
       }
     },
     "array.prototype.flatmap": {
@@ -18439,12 +18102,6 @@
         "fill-range": "^7.1.1"
       }
     },
-    "brcast": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
-      "integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg==",
-      "dev": true
-    },
     "browserslist": {
       "version": "4.25.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
@@ -18710,12 +18367,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "consolidated-events": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
-      "integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ==",
-      "dev": true
     },
     "content-disposition": {
       "version": "1.0.0",
@@ -19088,12 +18739,6 @@
       "optional": true,
       "peer": true
     },
-    "direction": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
-      "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
-      "dev": true
-    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -19101,15 +18746,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "document.contains": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.2.tgz",
-      "integrity": "sha512-YcvYFs15mX8m3AO1QNQy3BlIpSMfNRj3Ujk2BEJxsZG+HZf7/hZ6jr7mDpXrF8q+ff95Vef5yjhiZxm8CGJr6Q==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3"
       }
     },
     "dom-accessibility-api": {
@@ -19217,16 +18853,6 @@
       "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
       "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
       "dev": true
-    },
-    "enzyme-shallow-equal": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.5.tgz",
-      "integrity": "sha512-i6cwm7hN630JXenxxJFBKzgLC3hMTafFQXflvzHgPmDhOBhxUWDe8AeRv1qp2/uWJ2Y8z5yLWMzmAfkTOiOCZg==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3",
-        "object-is": "^1.1.5"
-      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -20276,16 +19902,6 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
-    "global-cache": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/global-cache/-/global-cache-1.2.1.tgz",
-      "integrity": "sha512-EOeUaup5DgWKlCMhA9YFqNRIlZwoxt731jCh47WBV9fQqHgXhr3Fa55hfgIUqilIcPsfdNKN7LHjrNY+Km40KA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "is-symbol": "^1.0.1"
-      }
-    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -20366,15 +19982,6 @@
       "dev": true,
       "requires": {
         "duplexer": "^0.1.2"
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
       }
     },
     "has-bigints": {
@@ -20856,12 +20463,6 @@
         "has-symbols": "^1.1.0",
         "safe-regex-test": "^1.1.0"
       }
-    },
-    "is-touch-device": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-touch-device/-/is-touch-device-1.0.1.tgz",
-      "integrity": "sha512-LAYzo9kMT1b2p19L/1ATGt2XcSilnzNlyvq6c0pbPRVisLbAPpLqr53tIJS00kvrTkj0HtR8U7+u8X0yR8lPSw==",
-      "dev": true
     },
     "is-typed-array": {
       "version": "1.1.15",
@@ -23153,12 +22754,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
       "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
-    },
     "picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -23283,17 +22878,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "prop-types-exact": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
-      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "reflect.ownkeys": "^0.2.0"
-      }
-    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -23334,15 +22918,6 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
-    },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
     },
     "randombytes": {
       "version": "2.1.0",
@@ -23390,29 +22965,6 @@
         "no-scroll": "^2.1.1"
       }
     },
-    "react-dates": {
-      "version": "21.8.0",
-      "resolved": "https://registry.npmjs.org/react-dates/-/react-dates-21.8.0.tgz",
-      "integrity": "sha512-PPriGqi30CtzZmoHiGdhlA++YPYPYGCZrhydYmXXQ6RAvAsaONcPtYgXRTLozIOrsQ5mSo40+DiA5eOFHnZ6xw==",
-      "dev": true,
-      "requires": {
-        "airbnb-prop-types": "^2.15.0",
-        "consolidated-events": "^1.1.1 || ^2.0.0",
-        "enzyme-shallow-equal": "^1.0.0",
-        "is-touch-device": "^1.0.1",
-        "lodash": "^4.1.1",
-        "object.assign": "^4.1.0",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.2",
-        "raf": "^3.4.1",
-        "react-moment-proptypes": "^1.6.0",
-        "react-outside-click-handler": "^1.2.4",
-        "react-portal": "^4.2.0",
-        "react-with-direction": "^1.3.1",
-        "react-with-styles": "^4.1.0",
-        "react-with-styles-interface-css": "^6.0.0"
-      }
-    },
     "react-dom": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
@@ -23430,37 +22982,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "react-moment-proptypes": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.8.1.tgz",
-      "integrity": "sha512-Er940DxWoObfIqPrZNfwXKugjxMIuk1LAuEzn23gytzV6hKS/sw108wibi9QubfMN4h+nrlje8eUCSbQRJo2fQ==",
-      "dev": true,
-      "requires": {
-        "moment": ">=1.6.0"
-      }
-    },
-    "react-outside-click-handler": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz",
-      "integrity": "sha512-Te/7zFU0oHpAnctl//pP3hEAeobfeHMyygHB8MnjP6sX5OR8KHT1G3jmLsV3U9RnIYo+Yn+peJYWu+D5tUS8qQ==",
-      "dev": true,
-      "requires": {
-        "airbnb-prop-types": "^2.15.0",
-        "consolidated-events": "^1.1.1 || ^2.0.0",
-        "document.contains": "^1.0.1",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.2"
-      }
-    },
-    "react-portal": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.1.tgz",
-      "integrity": "sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
     },
     "react-router-dom": {
       "version": "5.3.0",
@@ -23526,53 +23047,6 @@
       "requires": {
         "@floating-ui/dom": "^1.6.1",
         "classnames": "^2.3.0"
-      }
-    },
-    "react-with-direction": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.4.0.tgz",
-      "integrity": "sha512-ybHNPiAmaJpoWwugwqry9Hd1Irl2hnNXlo/2SXQBwbLn/jGMauMS2y9jw+ydyX5V9ICryCqObNSthNt5R94xpg==",
-      "dev": true,
-      "requires": {
-        "airbnb-prop-types": "^2.16.0",
-        "brcast": "^2.0.2",
-        "deepmerge": "^1.5.2",
-        "direction": "^1.0.4",
-        "hoist-non-react-statics": "^3.3.2",
-        "object.assign": "^4.1.2",
-        "object.values": "^1.1.5",
-        "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "deepmerge": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
-          "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==",
-          "dev": true
-        }
-      }
-    },
-    "react-with-styles": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-4.2.0.tgz",
-      "integrity": "sha512-tZCTY27KriRNhwHIbg1NkSdTTOSfXDg6Z7s+Q37mtz0Ym7Sc7IOr3PzVt4qJhJMW6Nkvfi3g34FuhtiGAJCBQA==",
-      "dev": true,
-      "requires": {
-        "airbnb-prop-types": "^2.14.0",
-        "hoist-non-react-statics": "^3.2.1",
-        "object.assign": "^4.1.0",
-        "prop-types": "^15.7.2",
-        "react-with-direction": "^1.3.1"
-      }
-    },
-    "react-with-styles-interface-css": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-6.0.0.tgz",
-      "integrity": "sha512-6khSG1Trf4L/uXOge/ZAlBnq2O2PEXlQEqAhCRbvzaQU4sksIkdwpCPEl6d+DtP3+IdhyffTWuHDO9lhe1iYvA==",
-      "dev": true,
-      "requires": {
-        "array.prototype.flat": "^1.2.1",
-        "global-cache": "^1.2.1"
       }
     },
     "read-pkg": {
@@ -23648,12 +23122,6 @@
         "get-proto": "^1.0.1",
         "which-builtin-type": "^1.2.1"
       }
-    },
-    "reflect.ownkeys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
-      "dev": true
     },
     "regenerate": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "postcss-loader": "^8.1.1",
     "react": "^16.14.0",
     "react-aria-modal": "^5.0.2",
-    "react-dates": "^21.8.0",
     "react-dom": "^16.14.0",
     "react-router-dom": "^5.3.0",
     "react-tooltip": "^5.29.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "body-parser": "^2.2.0",
     "ejs": "^3.1.10",
     "express": "^5.1.0",
+    "luxon": "^3.6.1",
     "normalize.css": "^8.0.1"
   },
   "devDependencies": {
@@ -32,8 +33,6 @@
     "jest": "^30.0.0",
     "jest-environment-jsdom": "^30.0.0",
     "mini-css-extract-plugin": "^2.9.2",
-    "moment": "^2.30.1",
-    "moment-locales-webpack-plugin": "^1.2.0",
     "postcss": "^8.5.6",
     "postcss-loader": "^8.1.1",
     "react": "^16.14.0",

--- a/src/components/__tests__/search-bar.test.jsx
+++ b/src/components/__tests__/search-bar.test.jsx
@@ -46,16 +46,10 @@ describe('search-bar', () => {
 
   it('Handles date range search queries for startDate', () => {
     const onSearch = jest.fn();
-    render(<SearchBar inputIdSuffix="1" onSearch={onSearch} />);
-    
-    // To open and interact with the calendar, we first need to focus the input it's attached to.
-    const startDateInput = screen.getByLabelText(/start date/i);
-    fireEvent.focus(startDateInput);
+    render(<SearchBar onSearch={onSearch} />);
 
-    // The actual button text is something like "Choose Sunday, June 1, 2025, blah blah".
-    // This should get us close enough. There will be more than one (for the current and previous month).
-    const calendarDay = screen.getAllByRole('button', { name: /Choose .* 1,/ });
-    fireEvent.click(calendarDay[0]);
+    const startDateInput = screen.getByLabelText(/from date/i);
+    fireEvent.change(startDateInput, { target: { value: '2025-06-01' } });
 
     expect(onSearch).toHaveBeenCalledWith({
       url: null,
@@ -66,15 +60,10 @@ describe('search-bar', () => {
 
   it('Handles date range search queries for endDate', () => {
     const onSearch = jest.fn();
-    render(<SearchBar inputIdSuffix="1" onSearch={onSearch} />);
-    
-    const endDateInput = screen.getByLabelText(/end date/i);
-    fireEvent.focus(endDateInput);
+    render(<SearchBar onSearch={onSearch} />);
 
-    // The actual button text is something like "Choose Sunday, June 1, 2025, blah blah".
-    // This should get us close enough. There will be more than one (for the current and previous month).
-    const calendarDay = screen.getAllByRole('button', { name: /Choose .* 1,/ });
-    fireEvent.click(calendarDay[0]);
+    const endDateInput = screen.getByLabelText(/to date/i);
+    fireEvent.change(endDateInput, { target: { value: '2025-06-01' } });
 
     expect(onSearch).toHaveBeenCalledWith({
       url: null,

--- a/src/components/__tests__/search-bar.test.jsx
+++ b/src/components/__tests__/search-bar.test.jsx
@@ -2,7 +2,7 @@
 
 import { render, screen, fireEvent } from '@testing-library/react';
 import SearchBar from '../search-bar/search-bar';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 
 describe('search-bar', () => {
   // Need to use a fake timer because the _urlSearch function is debounced.
@@ -53,7 +53,7 @@ describe('search-bar', () => {
 
     expect(onSearch).toHaveBeenCalledWith({
       url: null,
-      startDate: expect.any(moment),
+      startDate: expect.any(DateTime),
       endDate: null
     });
   });
@@ -68,7 +68,7 @@ describe('search-bar', () => {
     expect(onSearch).toHaveBeenCalledWith({
       url: null,
       startDate: null,
-      endDate: expect.any(moment)
+      endDate: expect.any(DateTime)
     });
   });
 });

--- a/src/components/search-bar/search-bar.css
+++ b/src/components/search-bar/search-bar.css
@@ -2,11 +2,12 @@
   border-bottom: 1px solid var(--default-border);
   margin-bottom: 0.5em;
   display: flex;
+  font-size: 1.25em;
+  line-height: 2.15;
 }
 
 .search-bar-input {
   border: none;
-  font-size: 1.25em;
-  padding: 0.5em 15px;
+  padding: 0 15px;
   flex-grow: 2;
 }

--- a/src/components/search-bar/search-bar.jsx
+++ b/src/components/search-bar/search-bar.jsx
@@ -2,6 +2,8 @@ import { Component } from 'react';
 import styles from './search-bar.css';
 import SearchDatePicker from '../search-date-picker/search-date-picker';
 
+/** @typedef {import("luxon").DateTime} DateTime */
+
 /**
  * @typedef SearchBarProps
  * @property {(SearchBarQuery) => void} onSearch
@@ -87,8 +89,8 @@ export default class SearchBar extends Component {
   /**
    * Updates query state with date range information.
    *
-   * @param {Date} startDate moment object from date picker
-   * @param {Date} endDate moment object from date picker
+   * @param {DateTime} startDate Luxon DateTime object from date picker
+   * @param {DateTime} endDate Luxon DateTime object from date picker
    */
   _dateSearch ({ startDate, endDate }) {
     this.setState({ startDate, endDate });

--- a/src/components/search-bar/search-bar.jsx
+++ b/src/components/search-bar/search-bar.jsx
@@ -1,6 +1,6 @@
 import { Component } from 'react';
 import styles from './search-bar.css';
-import SearchDatePicker from '../search-date-picker';
+import SearchDatePicker from '../search-date-picker/search-date-picker';
 
 /**
  * @typedef SearchBarProps

--- a/src/components/search-date-picker.jsx
+++ b/src/components/search-date-picker.jsx
@@ -1,15 +1,11 @@
 import { Component } from 'react';
-import 'react-dates/initialize';
-import { DateRangePicker } from 'react-dates';
-import 'react-dates/lib/css/_datepicker.css';
 import moment from 'moment';
-import { isInclusivelyBeforeDay } from 'react-dates';
 
 /**
  * @typedef SearchDatePickerProps
- * @property {({startDate: Moment, endDate: Moment}) => void} onDateSearch
- * @property {Date} startDate
- * @property {Date} endDate
+ * @property {({startDate: moment.Moment, endDate: Moment.moment}) => void} onDateSearch
+ * @property {Date|moment.Moment} startDate
+ * @property {Date|moment.Moment} endDate
  */
 
 /**
@@ -25,21 +21,40 @@ export default class SearchDatePicker extends Component {
   constructor (props) {
     super(props);
     this.state = { focusedInput: null };
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange (event) {
+    const value = event.target.value ? moment(event.target.value) : null;
+    this.props.onDateSearch({
+      startDate: this.props.startDate,
+      endDate: this.props.endDate,
+      [event.target.name]: value,
+    });
   }
 
   render () {
     return (
-      <DateRangePicker
-        startDateId={'startDate' + (this.props.inputIdSuffix || '')}
-        endDateId={'endDate' + (this.props.inputIdSuffix || '')}
-        startDate={this.props.startDate}
-        endDate={this.props.endDate}
-        onDatesChange={this.props.onDateSearch}
-        focusedInput={this.state.focusedInput}
-        onFocusChange={(focusedInput) => { this.setState({ focusedInput });}}
-        isOutsideRange={day => !isInclusivelyBeforeDay(day, moment())}
-        readOnly
-        showClearDates />
+      <>
+        <label className="searchDateField">
+          From date:
+          <input
+            type="date"
+            name="startDate"
+            value={this.props.startDate?.toISOString()?.slice(0, 10) ?? ''}
+            onChange={this.handleChange}
+          />
+        </label>
+        <label className="searchDateField">
+          To date:
+          <input
+            type="date"
+            name="endDate"
+            value={this.props.endDate?.toISOString()?.slice(0, 10) ?? ''}
+            onChange={this.handleChange}
+          />
+        </label>
+      </>
     );
   }
 }

--- a/src/components/search-date-picker/search-date-picker.css
+++ b/src/components/search-date-picker/search-date-picker.css
@@ -1,0 +1,12 @@
+.search-date-field {
+  border-left: 1px solid var(--default-border);
+  padding: 0 0.5em;
+  font-weight: normal;
+  color: var(--gray-light);
+  margin-bottom: 0;
+
+  input {
+    border: none;
+    margin-left: 0.1em;
+  }
+}

--- a/src/components/search-date-picker/search-date-picker.jsx
+++ b/src/components/search-date-picker/search-date-picker.jsx
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 import moment from 'moment';
+import styles from './search-date-picker.css';
 
 /**
  * @typedef SearchDatePickerProps
@@ -36,22 +37,24 @@ export default class SearchDatePicker extends Component {
   render () {
     return (
       <>
-        <label className="searchDateField">
+        <label className={styles.searchDateField}>
           From date:
           <input
             type="date"
             name="startDate"
             value={this.props.startDate?.toISOString()?.slice(0, 10) ?? ''}
             onChange={this.handleChange}
+            max={(new Date()).toISOString().slice(0, 10)}
           />
         </label>
-        <label className="searchDateField">
+        <label className={styles.searchDateField}>
           To date:
           <input
             type="date"
             name="endDate"
             value={this.props.endDate?.toISOString()?.slice(0, 10) ?? ''}
             onChange={this.handleChange}
+            max={moment().add(1, 'days').toISOString().slice(0, 10)}
           />
         </label>
       </>

--- a/src/components/search-date-picker/search-date-picker.jsx
+++ b/src/components/search-date-picker/search-date-picker.jsx
@@ -1,12 +1,11 @@
-import { Component } from 'react';
 import { DateTime } from 'luxon';
 import styles from './search-date-picker.css';
 
 /**
  * @typedef SearchDatePickerProps
- * @property {({startDate: DateTime, endDate: DateTime}) => void} onDateSearch
- * @property {DateTime} startDate
- * @property {DateTime} endDate
+ * @property {({startDate: DateTime|null, endDate: DateTime|null}) => void} onDateSearch
+ * @property {DateTime?} startDate
+ * @property {DateTime?} endDate
  */
 
 /**
@@ -14,50 +13,40 @@ import styles from './search-date-picker.css';
  * Once a date is selected, onDateSearch function is called with startDate and endDate values.
  * Dates can also be cleared out after selected.
  *
- * @class SearchDatePicker
- * @extends {Component}
  * @param {SearchDatePickerProps} props
  */
-export default class SearchDatePicker extends Component {
-  constructor (props) {
-    super(props);
-    this.state = { focusedInput: null };
-    this.handleChange = this.handleChange.bind(this);
-  }
-
-  handleChange (event) {
+export default function SearchDatePicker ({ onDateSearch, startDate = null, endDate = null }) {
+  function handleChange (event) {
     const value = event.target.value ? DateTime.fromISO(event.target.value) : null;
-    this.props.onDateSearch({
-      startDate: this.props.startDate,
-      endDate: this.props.endDate,
+    onDateSearch({
+      startDate,
+      endDate,
       [event.target.name]: value,
     });
   }
 
-  render () {
-    return (
-      <>
-        <label className={styles.searchDateField}>
-          From date:
-          <input
-            type="date"
-            name="startDate"
-            value={this.props.startDate?.toISODate() ?? ''}
-            onChange={this.handleChange}
-            max={DateTime.now().toISODate()}
-          />
-        </label>
-        <label className={styles.searchDateField}>
-          To date:
-          <input
-            type="date"
-            name="endDate"
-            value={this.props.endDate?.toISODate() ?? ''}
-            onChange={this.handleChange}
-            max={DateTime.now().plus({ days: 1 }).toISODate()}
-          />
-        </label>
-      </>
-    );
-  }
+  return (
+    <>
+      <label className={styles.searchDateField}>
+        From date:
+        <input
+          type="date"
+          name="startDate"
+          value={startDate?.toISODate() ?? ''}
+          onChange={handleChange}
+          max={DateTime.now().toISODate()}
+        />
+      </label>
+      <label className={styles.searchDateField}>
+        To date:
+        <input
+          type="date"
+          name="endDate"
+          value={endDate?.toISODate() ?? ''}
+          onChange={handleChange}
+          max={DateTime.now().plus({ days: 1 }).toISODate()}
+        />
+      </label>
+    </>
+  );
 }

--- a/src/components/search-date-picker/search-date-picker.jsx
+++ b/src/components/search-date-picker/search-date-picker.jsx
@@ -1,12 +1,12 @@
 import { Component } from 'react';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import styles from './search-date-picker.css';
 
 /**
  * @typedef SearchDatePickerProps
- * @property {({startDate: moment.Moment, endDate: Moment.moment}) => void} onDateSearch
- * @property {Date|moment.Moment} startDate
- * @property {Date|moment.Moment} endDate
+ * @property {({startDate: DateTime, endDate: DateTime}) => void} onDateSearch
+ * @property {DateTime} startDate
+ * @property {DateTime} endDate
  */
 
 /**
@@ -26,7 +26,7 @@ export default class SearchDatePicker extends Component {
   }
 
   handleChange (event) {
-    const value = event.target.value ? moment(event.target.value) : null;
+    const value = event.target.value ? DateTime.fromISO(event.target.value) : null;
     this.props.onDateSearch({
       startDate: this.props.startDate,
       endDate: this.props.endDate,
@@ -42,9 +42,9 @@ export default class SearchDatePicker extends Component {
           <input
             type="date"
             name="startDate"
-            value={this.props.startDate?.toISOString()?.slice(0, 10) ?? ''}
+            value={this.props.startDate?.toISODate() ?? ''}
             onChange={this.handleChange}
-            max={(new Date()).toISOString().slice(0, 10)}
+            max={DateTime.now().toISODate()}
           />
         </label>
         <label className={styles.searchDateField}>
@@ -52,9 +52,9 @@ export default class SearchDatePicker extends Component {
           <input
             type="date"
             name="endDate"
-            value={this.props.endDate?.toISOString()?.slice(0, 10) ?? ''}
+            value={this.props.endDate?.toISODate() ?? ''}
             onChange={this.handleChange}
-            max={moment().add(1, 'days').toISOString().slice(0, 10)}
+            max={DateTime.now().plus({ days: 1 }).toISODate()}
           />
         </label>
       </>

--- a/src/scripts/__tests__/db-helpers.test.js
+++ b/src/scripts/__tests__/db-helpers.test.js
@@ -1,11 +1,11 @@
 /* eslint-env jest */
 import { formatDateRange } from '../db-helpers';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 
 describe('db-helpers', () => {
-  test('formatDateRange returns correct query parameter value when moment object is passed in', () => {
-    const startDate = moment('26 Oct 2019 21:00:00 PST');
-    const endDate = moment('27 Oct 2019 21:00:00 PST');
+  test('formatDateRange returns correct query parameter value when DateTime object is passed in', () => {
+    const startDate = DateTime.fromISO('2019-10-26T21:00:00-08:00');
+    const endDate = DateTime.fromISO('2019-10-27T21:00:00-08:00');
     const dateRangeString = formatDateRange({ startDate, endDate });
 
     expect(dateRangeString).toBe('2019-10-27T05:00:00.000Z..2019-10-28T05:00:00.000Z');

--- a/src/scripts/db-helpers.js
+++ b/src/scripts/db-helpers.js
@@ -1,16 +1,19 @@
+/** @typedef {import("luxon").DateTime} DateTime */
+
 /**
- * Takes a date (either a moment or Date object) and returns an ISO date string in UTC time.
- * If there is no date, return an empty string.
+ * Takes a date (either a Luxon DateTime or Date object) and returns an ISO date
+ * string in UTC time. If there is no date, return an empty string.
  * Throws a TypeError if an invalid value is passed in.
  * @private
- * @param {String|Date|Moment} date
+ * @param {String|Date|DateTime} date
  *
  * @returns {String}
  */
 function _formatDate (date) {
   if (!date) return '';
+  else if (date.toISO) return date.toUTC().toISO();
   else if (date.toISOString) return date.toISOString();
-  else throw new TypeError(`formatDate only takes Moment or Date instances, not ${date.constructor.name}s`);
+  else throw new TypeError(`formatDate only takes Date or luxon.DateTime instances, not ${date.constructor.name}s`);
 }
 
 /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 const autoprefixer = require('autoprefixer');
 const CompressionPlugin = require('compression-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const path = require('path');
 const zopfli = require('@gfx/zopfli');
 
@@ -132,8 +131,6 @@ module.exports = {
   },
   plugins: [
     new MiniCssExtractPlugin({ runtime: false }),
-    // Strip locales from Moment.js (we only use English)
-    new MomentLocalesPlugin()
   ],
 };
 


### PR DESCRIPTION
React-dates is not compatible with React 17+, and is preventing us from upgrading lots of other tools and packages to currently supported versions. The author stated it won't be upgraded until Enzyme is, and my current belief is that Enzyme is effectively dead. This removes it so we can move forward.

This also switches us from Moment to Luxon for time handling. Moment has been deprecated for years, and we only remained on it because react-dates depended on it.

Part of the modernization work in #1082.