### PR TITLE
Discourage robots from indexing this app

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -79,6 +79,7 @@ else {
 
 app.set('views', path.join(__dirname, '../views'));
 app.engine('html', require('ejs').renderFile);
+app.engine('txt', require('ejs').renderFile);
 app.use(bodyParser.json());
 
 app.get('/healthcheck', function (request, response) {
@@ -149,6 +150,11 @@ app.post(
       .catch(createErrorHandler(response));
   }
 );
+
+app.get('/robots.txt', function (_request, response) {
+  response.header('Content-Type', 'text/plain');
+  response.render('robots.txt');
+});
 
 /**
  * Main view for manual entry

--- a/views/main.html
+++ b/views/main.html
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="robots" content="noindex" />
 
         <title>Scanner</title>
 

--- a/views/robots.txt
+++ b/views/robots.txt
@@ -1,0 +1,4 @@
+# This is purely a dynamic web app and doesn't really have meaningful "pages"
+# as such. It shouldn't really be indexed or crawled at all.
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Per a discussion with the team, it's probably not good or useful if random comparison views from this app show up on Google, or if Internet Archive archives our view of their archives. (Context: since we show a lot of pages that no longer exist, Google has started pointing to us for some things! But we're not really an optimal view of a historical capture -- people should go to the Internet Archive for that.)

This solves the issue by adding a `robots.txt` and robots meta directives.