### PR TITLE
Fix `diffTypesFor()` when using a file extension

### DIFF
--- a/src/constants/__tests__/diff-types.test.js
+++ b/src/constants/__tests__/diff-types.test.js
@@ -1,0 +1,21 @@
+/* eslint-env jest */
+
+import { diffTypes, diffTypesFor } from '../diff-types';
+import MediaType from '../../scripts/media-type';
+
+describe('diffTypesFor', () => {
+  it('accepts a file extension', () => {
+    const result = diffTypesFor('.html');
+    expect(result).toContain(diffTypes.HIGHLIGHTED_RENDERED);
+  });
+
+  it('accepts a media type string', () => {
+    const result = diffTypesFor('text/html');
+    expect(result).toContain(diffTypes.HIGHLIGHTED_RENDERED);
+  });
+
+  it('accepts a MediaType object', () => {
+    const result = diffTypesFor(MediaType('text', 'html'));
+    expect(result).toContain(diffTypes.HIGHLIGHTED_RENDERED);
+  });
+});

--- a/src/constants/diff-types.js
+++ b/src/constants/diff-types.js
@@ -81,7 +81,7 @@ const diffTypesByMediaType = {
 export function diffTypesFor (mediaType) {
   let type = null;
   if (typeof mediaType === 'string' && mediaType.startsWith('.')) {
-    type = mediaTypeForExtension(mediaType) || unknownType;
+    type = mediaTypeForExtension[mediaType] || unknownType;
   }
   else {
     type = parseMediaType(mediaType);


### PR DESCRIPTION
The `diffTypesFor()` function is intended to allow you to pass in a MediaType object, media type string, or a file extension (e.g. `".pdf"`). However, it turns out the file extension is broken (I guess we have pretty much stopped using file extensions since we improved media type support way back when...). This fixes the issue and adds a test.

This bug was originally uncovered by @BeckettFrey in #1095. Thanks! 🙇 