### PR TITLE
Upgrade React Router to v6.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "react": "^18.3.1",
         "react-aria-modal": "^5.0.2",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^5.3.4",
+        "react-router-dom": "^6.30.1",
         "react-tooltip": "^5.29.1",
         "style-loader": "^4.0.0",
         "webpack": "^5.101.3",
@@ -2995,6 +2995,16 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.41",
@@ -6964,31 +6974,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -7659,13 +7644,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -10014,53 +9992,37 @@
       "dev": true
     },
     "node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/react-router/node_modules/path-to-regexp": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
-      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-tooltip": {
@@ -10329,13 +10291,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -11296,20 +11251,6 @@
         "tslib": "^2"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tldts": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
@@ -11747,13 +11688,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -14345,6 +14279,12 @@
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true
+    },
+    "@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
       "dev": true
     },
     "@sinclair/typebox": {
@@ -17095,29 +17035,6 @@
         "function-bind": "^1.1.2"
       }
     },
-    "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
-    "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
-      "requires": {
-        "react-is": "^16.7.0"
-      }
-    },
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -17552,12 +17469,6 @@
         "call-bound": "^1.0.3",
         "get-intrinsic": "^1.2.6"
       }
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -19182,46 +19093,22 @@
       "dev": true
     },
     "react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "path-to-regexp": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
-          "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        }
+        "@remix-run/router": "1.23.0"
       }
     },
     "react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
       }
     },
     "react-tooltip": {
@@ -19418,12 +19305,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true
-    },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
       "dev": true
     },
     "reusify": {
@@ -20114,18 +19995,6 @@
       "dev": true,
       "requires": {}
     },
-    "tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "dev": true
-    },
     "tldts": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
@@ -20428,12 +20297,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "dev": true
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react": "^18.3.1",
     "react-aria-modal": "^5.0.2",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^5.3.4",
+    "react-router-dom": "^6.30.1",
     "react-tooltip": "^5.29.1",
     "style-loader": "^4.0.0",
     "webpack": "^5.101.3",

--- a/src/components/__tests__/page-details.test.jsx
+++ b/src/components/__tests__/page-details.test.jsx
@@ -12,11 +12,9 @@ describe('page-details', () => {
   simplePage.versions.forEach(version => {
     version.capture_time = new Date(version.capture_time);
   });
-  const match = {
-    params: {
-      pageId: simplePage.uuid,
-      change: `${simplePage.versions[1].uuid}..${simplePage.versions[0].uuid}`,
-    }
+  const urlParams = {
+    pageId: simplePage.uuid,
+    change: `${simplePage.versions[1].uuid}..${simplePage.versions[0].uuid}`,
   };
   const createMockApi = () => {
     let samples = simplePage.versions.reduce((samples, version) => {
@@ -49,7 +47,7 @@ describe('page-details', () => {
     const mockApi = createMockApi();
     render(
       <ApiContext.Provider value={{ api: mockApi }}>
-        <PageDetails match={match} />
+        <PageDetails {...urlParams} />
       </ApiContext.Provider>
     );
 
@@ -60,7 +58,7 @@ describe('page-details', () => {
     const mockApi = createMockApi();
     const { unmount } = render(
       <ApiContext.Provider value={{ api: mockApi }}>
-        <PageDetails match={match} />
+        <PageDetails {...urlParams} />
       </ApiContext.Provider>
     );
 
@@ -78,13 +76,8 @@ describe('page-details', () => {
     const { container } = render(
       <ApiContext.Provider value={{ api: mockApi }}>
         <PageDetails
-          match={{
-            ...match,
-            params: {
-              ...match.params,
-              change: `${allVersions.at(-1).uuid}..${allVersions[0].uuid}`
-            }
-          }}
+          {...urlParams}
+          change={`${allVersions.at(-1).uuid}..${allVersions[0].uuid}`}
         />,
       </ApiContext.Provider>
     );

--- a/src/components/__tests__/page-details.test.jsx
+++ b/src/components/__tests__/page-details.test.jsx
@@ -47,7 +47,7 @@ describe('page-details', () => {
     const mockApi = createMockApi();
     render(
       <ApiContext.Provider value={{ api: mockApi }}>
-        <PageDetails {...urlParams} />
+        <PageDetails urlParams={urlParams} />
       </ApiContext.Provider>
     );
 
@@ -58,7 +58,7 @@ describe('page-details', () => {
     const mockApi = createMockApi();
     const { unmount } = render(
       <ApiContext.Provider value={{ api: mockApi }}>
-        <PageDetails {...urlParams} />
+        <PageDetails urlParams={urlParams} />
       </ApiContext.Provider>
     );
 
@@ -76,8 +76,10 @@ describe('page-details', () => {
     const { container } = render(
       <ApiContext.Provider value={{ api: mockApi }}>
         <PageDetails
-          {...urlParams}
-          change={`${allVersions.at(-1).uuid}..${allVersions[0].uuid}`}
+          urlParams={{
+            ...urlParams,
+            change: `${allVersions.at(-1).uuid}..${allVersions[0].uuid}`
+          }}
         />,
       </ApiContext.Provider>
     );

--- a/src/components/__tests__/page-list.test.jsx
+++ b/src/components/__tests__/page-list.test.jsx
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 
 import { fireEvent, render, screen, act } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import PageList from '../page-list/page-list';
 import simplePages from '../../__mocks__/simple-pages.json';
 
@@ -21,8 +22,19 @@ describe('page-list', () => {
     record.latest.capture_time = new Date(record.latest.capture_time);
   });
 
+  function renderContext (element, options) {
+    return render(
+      (
+        <Router future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+          {element}
+        </Router>
+      ),
+      options
+    );
+  }
+
   it('can render', () => {
-    const { container } = render(
+    const { container } = renderContext(
       <PageList />
     );
 
@@ -30,35 +42,35 @@ describe('page-list', () => {
   });
 
   it('shows domain without www prefix', () => {
-    render(<PageList pages={simplePages} />);
+    renderContext(<PageList pages={simplePages} />);
     screen.getByText('ncei.noaa.gov');
   });
 
   it('shows non-URL related tags', () => {
-    const { container } = render(<PageList pages={simplePages} />);
+    const { container } = renderContext(<PageList pages={simplePages} />);
 
     const tagsCell = container.querySelector('tbody tr:nth-child(1) td:nth-child(4)');
     expect(tagsCell).toHaveTextContent('Human');
   });
 
   it('displays SearchBar component', () => {
-    render(<PageList />);
+    renderContext(<PageList />);
     expect(screen.getByPlaceholderText('Search for a URL...')).toBeInTheDocument();
   });
 
   it('displays Loading component when there are no pages', () => {
-    render(<PageList />);
+    renderContext(<PageList />);
     screen.getByText(/loading/i);
   });
 
   it('does not display Loading component when there are pages', () => {
-    render(<PageList pages={simplePages} />);
+    renderContext(<PageList pages={simplePages} />);
     expect(screen.queryByText(/loading/i)).toBeNull();
   });
 
   it('opens a new window when a user control clicks on a page row', async () => {
     global.open = jest.fn();
-    render(<PageList pages={simplePages} />);
+    renderContext(<PageList pages={simplePages} />);
 
     const page = simplePages[0];
     await act(() => {
@@ -72,7 +84,7 @@ describe('page-list', () => {
 
   it('opens a new window when a user command clicks on a page row', async () => {
     global.open = jest.fn();
-    render(<PageList pages={simplePages} />);
+    renderContext(<PageList pages={simplePages} />);
 
     const page = simplePages[0];
     await act(() => {

--- a/src/components/nav-bar/nav-bar.jsx
+++ b/src/components/nav-bar/nav-bar.jsx
@@ -20,7 +20,13 @@ export default ({ children = null, title = 'EDGI Web Monitoring', user = null, s
       <Link to="/" className={navStyles.brand}>{title}</Link>
       <ul className={navStyles.navList}>
         <li>
-          <NavLink to="/pages" activeClassName={navStyles.navLinkActive} className={navStyles.navLink} exact>
+          <NavLink
+            to="/pages"
+            end
+            className={({ isActive }) => [
+              navStyles.navLink, isActive ? navStyles.navLinkActive : ''
+            ].join(' ')}
+          >
             All Pages
           </NavLink>
         </li>

--- a/src/components/page-details/page-details.jsx
+++ b/src/components/page-details/page-details.jsx
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { Link, Redirect } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import { ApiContext } from '../api-context';
 import ChangeView from '../change-view/change-view';
 import Loading from '../loading';
@@ -17,6 +17,7 @@ import pageStyles from './page-details.css';
  * @typedef {Object} PageDetailsProps
  * @property {Page[]} pages
  * @property {Object} user
+ * @property {(to: string, options: any) => void} navigate
  */
 
 /**
@@ -34,7 +35,7 @@ export default class PageDetails extends Component {
 
   static getDerivedStateFromProps (props, state) {
     // Clear existing content when switching pages
-    if (state.page && state.page.uuid !== props.match.params.pageId) {
+    if (state.page && state.page.uuid !== props.pageId) {
       return { page: null };
     }
     return null;
@@ -43,7 +44,7 @@ export default class PageDetails extends Component {
   componentDidMount () {
     this.isMounted = true;
     window.addEventListener('keydown', this);
-    this._loadPage(this.props.match.params.pageId);
+    this._loadPage(this.props.pageId);
   }
 
   componentWillUnmount () {
@@ -57,8 +58,8 @@ export default class PageDetails extends Component {
    */
   componentDidUpdate (previousProps) {
     this.setTitle();
-    const nextPageId = this.props.match.params.pageId;
-    if (nextPageId !== previousProps.match.params.pageId) {
+    const nextPageId = this.props.pageId;
+    if (nextPageId !== previousProps.pageId) {
       this._loadPage(nextPageId);
     }
   }
@@ -74,7 +75,7 @@ export default class PageDetails extends Component {
    */
   handleEvent (event) {
     if (event.keyCode === 27) {
-      this.props.history.push('/');
+      this.props.navigate('/');
     }
   }
 
@@ -111,8 +112,8 @@ export default class PageDetails extends Component {
 
     if (this.state.page.merged_into) {
       const targetId = this.state.page.merged_into;
-      const changeId = this.props.match.params.change || '';
-      return <Redirect to={`/page/${targetId}/${changeId}`} />;
+      const changeId = this.props.change || '';
+      return <Navigate to={`/page/${targetId}/${changeId}`} replace />;
     }
 
     const statusCode = this.state.page.status || 200;
@@ -221,7 +222,7 @@ export default class PageDetails extends Component {
       );
     }
     else if (targetUrl) {
-      return <Redirect to={targetUrl} />;
+      return <Navigate to={targetUrl} replace />;
     }
     else if (!(versionData.from && versionData.to)) {
       return <div className={[baseStyles.alert, baseStyles.alertDanger].join(' ')}>No saved versions of this page.</div>;
@@ -245,7 +246,7 @@ export default class PageDetails extends Component {
    * @returns {[string|null, string|null]}
    */
   _versionIdsFromProps () {
-    return (this.props.match.params.change || '').split('..');
+    return (this.props.change || '').split('..');
   }
 
   /**
@@ -370,12 +371,12 @@ export default class PageDetails extends Component {
 
   _getChangeUrl (from, to, page) {
     const changeId = (from && to) ? `${from.uuid}..${to.uuid}` : '';
-    const pageId = page && page.uuid || this.props.match.params.pageId;
+    const pageId = page && page.uuid || this.props.pageId;
     return `/page/${pageId}/${changeId}`;
   }
 
   _navigateToChange = (from, to, page, replace = false) => {
     const url = this._getChangeUrl(from, to, page);
-    this.props.history[replace ? 'replace' : 'push'](url);
+    this.props.navigate(url, { replace });
   };
 }

--- a/src/components/page-details/page-details.jsx
+++ b/src/components/page-details/page-details.jsx
@@ -35,7 +35,7 @@ export default class PageDetails extends Component {
 
   static getDerivedStateFromProps (props, state) {
     // Clear existing content when switching pages
-    if (state.page && state.page.uuid !== props.pageId) {
+    if (state.page && state.page.uuid !== props.urlParams.pageId) {
       return { page: null };
     }
     return null;
@@ -44,7 +44,7 @@ export default class PageDetails extends Component {
   componentDidMount () {
     this.isMounted = true;
     window.addEventListener('keydown', this);
-    this._loadPage(this.props.pageId);
+    this._loadPage(this.props.urlParams.pageId);
   }
 
   componentWillUnmount () {
@@ -58,8 +58,8 @@ export default class PageDetails extends Component {
    */
   componentDidUpdate (previousProps) {
     this.setTitle();
-    const nextPageId = this.props.pageId;
-    if (nextPageId !== previousProps.pageId) {
+    const nextPageId = this.props.urlParams.pageId;
+    if (nextPageId !== previousProps.urlParams.pageId) {
       this._loadPage(nextPageId);
     }
   }
@@ -112,7 +112,7 @@ export default class PageDetails extends Component {
 
     if (this.state.page.merged_into) {
       const targetId = this.state.page.merged_into;
-      const changeId = this.props.change || '';
+      const changeId = this.props.urlParams.change || '';
       return <Navigate to={`/page/${targetId}/${changeId}`} replace />;
     }
 
@@ -246,7 +246,7 @@ export default class PageDetails extends Component {
    * @returns {[string|null, string|null]}
    */
   _versionIdsFromProps () {
-    return (this.props.change || '').split('..');
+    return (this.props.urlParams.change || '').split('..');
   }
 
   /**
@@ -371,7 +371,7 @@ export default class PageDetails extends Component {
 
   _getChangeUrl (from, to, page) {
     const changeId = (from && to) ? `${from.uuid}..${to.uuid}` : '';
-    const pageId = page && page.uuid || this.props.pageId;
+    const pageId = page && page.uuid || this.props.urlParams.pageId;
     return `/page/${pageId}/${changeId}`;
   }
 

--- a/src/components/page-list/page-list.jsx
+++ b/src/components/page-list/page-list.jsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import Loading from '../loading';
 import { Component } from 'react';
 import SearchBar from '../search-bar/search-bar';
@@ -60,7 +61,9 @@ export default class PageList extends Component {
         <table className={[listStyles.table, listStyles.pageList].join(' ')}>
           <thead>{this.renderHeader()}</thead>
           <tbody>
-            {this.props.pages.map(page => this.renderRow(page))}
+            {this.props.pages.map(page => (
+              <PageListRow page={page} key={page.uuid} />
+            ))}
           </tbody>
         </table>
       </div>
@@ -80,32 +83,6 @@ export default class PageList extends Component {
     );
   }
 
-  renderRow (record) {
-    const onClick = this.didClickRow.bind(this, record);
-    const tags = removeNonUserTags(record.tags);
-    const statusCode = record.status || 200;
-    let statusCategory = getHttpStatusCategory(statusCode);
-
-    return (
-      <tr key={record.uuid} onClick={onClick} data-name="info-row">
-        <td>{getDomain(record.url)}</td>
-        <td>{record.title}</td>
-        <td><a href={record.url} target="_blank" rel="noopener">{record.url}</a></td>
-        <td>{tags.map(tag => <PageTag tag={tag} key={tag.name} />)}</td>
-        <td
-          data-status-category={statusCategory}
-          data-tooltip-id="list-tooltip"
-          data-tooltip-content={describeHttpStatus(statusCode)}
-        >
-          {statusCode >= 400 ? '✘' : '•'} {record.status}
-        </td>
-        <td data-page-active={record.active.toString()}>
-          {record.active ? '•' : '✘'}
-        </td>
-      </tr>
-    );
-  }
-
   // TODO: we use similar markup elsewhere, consider making this a component
   renderError (message, type = 'danger') {
     return (
@@ -116,20 +93,49 @@ export default class PageList extends Component {
       </div>
     );
   }
+}
 
-  didClickRow (page, event) {
-    const relativeUrl = `/page/${page.uuid}`;
+/**
+ * React component that renders a single row in the PageList table.
+ */
+function PageListRow ({ page }) {
+  const navigate = useNavigate();
+  const detailsUrl = `/page/${page.uuid}`;
+  const tags = removeNonUserTags(page.tags);
+  const statusCode = page.status || 200;
+  const statusCategory = getHttpStatusCategory(statusCode);
+
+  const onClick = (event) => {
     if (isInAnchor(event.target)) {
       return;
     }
 
     if (event.ctrlKey || event.metaKey) {
-      window.open(relativeUrl, '_blank');
+      window.open(detailsUrl, '_blank');
       return;
     }
 
-    this.props.history.push(relativeUrl);
-  }
+    navigate(detailsUrl);
+  };
+
+  return (
+    <tr onClick={onClick} data-name="info-row">
+      <td>{getDomain(page.url)}</td>
+      <td>{page.title}</td>
+      <td><a href={page.url} target="_blank" rel="noopener">{page.url}</a></td>
+      <td>{tags.map(tag => <PageTag tag={tag} key={tag.name} />)}</td>
+      <td
+        data-status-category={statusCategory}
+        data-tooltip-id="list-tooltip"
+        data-tooltip-content={describeHttpStatus(statusCode)}
+      >
+        {statusCode >= 400 ? '✘' : '•'} {page.status}
+      </td>
+      <td data-page-active={page.active.toString()}>
+        {page.active ? '•' : '✘'}
+      </td>
+    </tr>
+  );
 }
 
 function isInAnchor (node) {

--- a/src/components/version-redirect.jsx
+++ b/src/components/version-redirect.jsx
@@ -1,46 +1,43 @@
 import Loading from './loading';
-import { Component } from 'react';
-import { Redirect } from 'react-router-dom';
+import { useContext, useEffect, useState } from 'react';
+import { Navigate, useParams } from 'react-router-dom';
 import { ApiContext } from './api-context';
 
 import styles from '../css/base.css';
 
-export default class VersionRedirect extends Component {
-  static contextType = ApiContext;
+export default function VersionRedirect () {
+  const api = useContext(ApiContext);
+  const { versionId } = useParams();
+  const [pageId, setPageId] = useState('');
+  const [error, setError] = useState(null);
 
-  constructor (props) {
-    super (props);
-    this.state = {
-      pageId: null,
-      error: null
-    };
-  }
-
-  componentDidMount () {
-    const versionId = this.props.match.params.versionId;
-    this.context.api.getVersion(versionId)
+  useEffect(() => {
+    let usable = true;
+    api.api.getVersion(versionId)
       .then(data => {
-        if (this.props.match.params.versionId === versionId) {
-          this.setState({ pageId: data.page_uuid });
+        if (usable) {
+          setPageId(data.page_uuid);
         }
       })
-      .catch(error => this.setState({ error: error }));
+      .catch(error => setError(error));
+
+    return () => {
+      usable = false;
+    };
+  }, [api, versionId]);
+
+  if (error) {
+    return (
+      <p className={[styles.alert, styles.alertDanger].join(' ')} role="alert">
+        Error: We couldn't find the version you're looking for.
+        Please check you provided the correct versionID.
+      </p>
+    );
   }
 
-  render () {
-    if (this.state.error) {
-      return (
-        <p className={[styles.alert, styles.alertDanger].join(' ')} role="alert">
-          Error: We couldn't find the version you're looking for.
-          Please check you provided the correct versionID.
-        </p>
-      );
-    }
-
-    if (!this.state.pageId) {
-      return <Loading />;
-    }
-
-    return <Redirect to={`/page/${this.state.pageId}/..${this.props.match.params.versionId}`} />;
+  if (!pageId) {
+    return <Loading />;
   }
+
+  return <Navigate to={`/page/${pageId}/..${versionId}`} replace />;
 }

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -158,7 +158,7 @@ export default class WebMonitoringUi extends Component {
       return (props) => {
         const urlParams = useParams();
         const navigate = useNavigate();
-        return <ComponentType navigate={navigate} {...urlParams} {...props} />;
+        return <ComponentType navigate={navigate} urlParams={urlParams} {...props} />;
       };
     };
     const PageListWithLoading = withUrlParams(withPages(PageList));

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -1,6 +1,6 @@
 import { Component } from 'react';
 import AriaModal from 'react-aria-modal';
-import { BrowserRouter as Router, Redirect, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Redirect, Route, Switch } from 'react-router-dom';
 import { ApiContext, WebMonitoringApi, WebMonitoringDb } from './api-context';
 import EnvironmentBanner from './environment-banner/environment-banner';
 import Loading from './loading';
@@ -164,16 +164,19 @@ export default class WebMonitoringUi extends Component {
             >
               <EnvironmentBanner apiUrl={api.url}/>
             </NavBar>
-            <Route exact path="/" render={() => <Redirect to="/pages" />}/>
-            <Route path="/pages" render={withData(PageList)} />
-            <Route path="/page/:pageId/:change?" render={(routeProps) =>
-              <PageDetails
-                {...routeProps}
-                user={this.state.user}
-                pages={this.state.pages}
-              />
-            }/>
-            <Route path="/version/:versionId" component={VersionRedirect} />
+
+            <Switch>
+              <Route exact path="/" render={() => <Redirect to="/pages" />}/>
+              <Route path="/pages" render={withData(PageList)} />
+              <Route path="/page/:pageId/:change?" render={(routeProps) =>
+                <PageDetails
+                  {...routeProps}
+                  user={this.state.user}
+                  pages={this.state.pages}
+                />
+              }/>
+              <Route path="/version/:versionId" component={VersionRedirect} />
+            </Switch>
             {modal}
           </div>
         </Router>

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -168,7 +168,7 @@ export default class WebMonitoringUi extends Component {
 
     return (
       <ApiContext.Provider value={{ api, localApi }}>
-        <Router future={{ v7_relativeSplatPath: true }}>
+        <Router future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
           <div id="application">
             <NavBar
               title="EDGI"


### PR DESCRIPTION
There are a whole bunch of changes here, but most revolve around converting small components to function components or wrapping more complex ones in function components, since v6 has embraced hooks wholesale, and there's not another way to do a lot of fundamental things anymore.

Part of #1082, obsoletes #1035.