### PR TITLE
Upgrade React Router to v7.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "react": "^18.3.1",
         "react-aria-modal": "^5.0.2",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.30.1",
+        "react-router": "^7.8.2",
         "react-tooltip": "^5.29.1",
         "style-loader": "^4.0.0",
         "webpack": "^5.101.3",
@@ -2995,16 +2995,6 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.41",
@@ -9992,37 +9982,36 @@
       "dev": true
     },
     "node_modules/react-router": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
-      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/react-router-dom": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
-      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.1"
-      },
       "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "node": ">=18"
       }
     },
     "node_modules/react-tooltip": {
@@ -10587,6 +10576,13 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -14279,12 +14275,6 @@
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
-      "dev": true
-    },
-    "@remix-run/router": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
       "dev": true
     },
     "@sinclair/typebox": {
@@ -19093,22 +19083,21 @@
       "dev": true
     },
     "react-router": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
-      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
       "dev": true,
       "requires": {
-        "@remix-run/router": "1.23.0"
-      }
-    },
-    "react-router-dom": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
-      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
-      "dev": true,
-      "requires": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.1"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+          "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+          "dev": true
+        }
       }
     },
     "react-tooltip": {
@@ -19526,6 +19515,12 @@
         "parseurl": "^1.3.3",
         "send": "^1.2.0"
       }
+    },
+    "set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "dev": true
     },
     "set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react": "^18.3.1",
     "react-aria-modal": "^5.0.2",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.30.1",
+    "react-router": "^7.8.2",
     "react-tooltip": "^5.29.1",
     "style-loader": "^4.0.0",
     "webpack": "^5.101.3",

--- a/src/components/__tests__/nav-bar.test.jsx
+++ b/src/components/__tests__/nav-bar.test.jsx
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 import { render, screen, getByRole } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import NavBar from '../nav-bar/nav-bar';
 
 test('navbar holds title and username', () => {

--- a/src/components/__tests__/page-details.test.jsx
+++ b/src/components/__tests__/page-details.test.jsx
@@ -64,7 +64,7 @@ describe('page-details', () => {
 
     await waitFor(() => expect(mockApi.getPage).toHaveBeenCalled());
     expect(mockApi.sampleVersions).toHaveBeenCalled();
-    expect(document.title).toBe('Scanner | http://www.ncei.noaa.gov/news/earth-science-conference-convenes');
+    await waitFor(() => expect(document.title).toBe(`Scanner | ${simplePage.url}`));
 
     unmount();
     expect(document.title).toBe('Scanner');

--- a/src/components/__tests__/page-list.test.jsx
+++ b/src/components/__tests__/page-list.test.jsx
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 import { fireEvent, render, screen, act } from '@testing-library/react';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router';
 import PageList from '../page-list/page-list';
 import simplePages from '../../__mocks__/simple-pages.json';
 
@@ -25,7 +25,7 @@ describe('page-list', () => {
   function renderContext (element, options) {
     return render(
       (
-        <Router future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <Router>
           {element}
         </Router>
       ),

--- a/src/components/nav-bar/nav-bar.jsx
+++ b/src/components/nav-bar/nav-bar.jsx
@@ -1,4 +1,4 @@
-import { Link, NavLink } from 'react-router-dom';
+import { Link, NavLink } from 'react-router';
 
 import baseStyles from '../../css/base.css';
 import navStyles from './nav-bar.css';

--- a/src/components/page-details/page-details.jsx
+++ b/src/components/page-details/page-details.jsx
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { Link, Navigate } from 'react-router-dom';
+import { Link, Navigate } from 'react-router';
 import { ApiContext } from '../api-context';
 import ChangeView from '../change-view/change-view';
 import Loading from '../loading';

--- a/src/components/page-list/page-list.jsx
+++ b/src/components/page-list/page-list.jsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import Loading from '../loading';
 import { Component } from 'react';
 import SearchBar from '../search-bar/search-bar';

--- a/src/components/version-redirect.jsx
+++ b/src/components/version-redirect.jsx
@@ -1,6 +1,6 @@
 import Loading from './loading';
 import { useContext, useEffect, useState } from 'react';
-import { Navigate, useParams } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router';
 import { ApiContext } from './api-context';
 
 import styles from '../css/base.css';

--- a/src/components/web-monitoring-ui.jsx
+++ b/src/components/web-monitoring-ui.jsx
@@ -1,6 +1,6 @@
 import { Component, useEffect } from 'react';
 import AriaModal from 'react-aria-modal';
-import { BrowserRouter as Router, Navigate, Routes, Route, useNavigate, useParams } from 'react-router-dom';
+import { BrowserRouter as Router, Navigate, Routes, Route, useNavigate, useParams } from 'react-router';
 import { ApiContext, WebMonitoringApi, WebMonitoringDb } from './api-context';
 import EnvironmentBanner from './environment-banner/environment-banner';
 import Loading from './loading';
@@ -168,7 +168,7 @@ export default class WebMonitoringUi extends Component {
 
     return (
       <ApiContext.Provider value={{ api, localApi }}>
-        <Router future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <Router>
           <div id="application">
             <NavBar
               title="EDGI"

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -1,1 +1,11 @@
+/* global globalThis */
+
 import '@testing-library/jest-dom';
+import nodeUtil from 'node:util';
+
+// Workaround for JSDOM not yet implementing TextEncoder, which React-Router
+// needs in the test environment: https://github.com/jsdom/jsdom/issues/2524
+if (!globalThis.TextEncoder || !globalThis.TextDecoder) {
+  globalThis.TextEncoder = nodeUtil.TextEncoder;
+  globalThis.TextDecoder = nodeUtil.TextDecoder;
+}


### PR DESCRIPTION
This one is pretty simple compared to v6! Mainly just swapping out `react-router-dom` for `react-router`. One annoying test-environment hack required.

Part of #1082, obviates #1076.