### PR TITLE
Move to ESM syntax everywhere

### DIFF
--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   'files': [
     // Catch-all in case we add other JS files
     {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -132,13 +132,12 @@ export default defineConfig([
   //   `formatters.js` from it).
   {
     files: [
-      '.bundlewatch.config.js',
+      // '.bundlewatch.config.js',
       'webpack.config.js',
-      'src/scripts/formatters.js',
+      // 'src/scripts/formatters.js',
     ],
 
     languageOptions: {
-      sourceType: 'commonjs',
       globals: {
         ...globals.node,
       },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "web-monitoring-ui",
   "main": "views/main.html",
+  "type": "module",
   "dependencies": {
     "@googleapis/sheets": "^11.1.0",
     "body-parser": "^2.2.0",

--- a/server/configuration.js
+++ b/server/configuration.js
@@ -1,4 +1,4 @@
-'use strict';
+import dotenv from 'dotenv';
 
 const defaultValues = {
   WEB_MONITORING_DB_URL: 'https://api.monitoring-staging.envirodatagov.org',
@@ -37,7 +37,7 @@ function parseBoolean (text, options = { default: false }) {
  * it may contain keys that must be kept secure.
  * @returns {Object}
  */
-function baseConfiguration () {
+export function baseConfiguration () {
   let localEnvironment = processEnvironment;
 
   if (processEnvironment.NODE_ENV !== 'production') {
@@ -46,7 +46,7 @@ function baseConfiguration () {
     // dotenv.config() updates process.env, but only with properties it doesn't
     // already have. That means it won't update properties that were previously
     // specified, so we have to do it manually here.
-    const fromFile = require('dotenv').config({ quiet: true });
+    const fromFile = dotenv.config({ quiet: true });
     // If there is no .env file, don't throw and just use process.env
     if (fromFile.error && fromFile.error.code !== 'ENOENT') {
       throw fromFile.error;
@@ -72,7 +72,7 @@ function baseConfiguration () {
  * Get a configuration object that is safe to pass to client code.
  * @returns {Object}
  */
-function clientConfiguration () {
+export function clientConfiguration () {
   const source = baseConfiguration();
 
   return clientFields.reduce((result, field) => {
@@ -80,6 +80,3 @@ function clientConfiguration () {
     return result;
   }, {});
 }
-
-exports.baseConfiguration = baseConfiguration;
-exports.clientConfiguration = clientConfiguration;

--- a/server/sheet-data.js
+++ b/server/sheet-data.js
@@ -1,11 +1,10 @@
-'use strict';
+import googleSheets from '@googleapis/sheets';
+import { baseConfiguration } from './configuration.js';
+import { formatMaintainers, formatSites } from '../src/scripts/formatters.js';
 
-const googleSheets = require('@googleapis/sheets');
-const config = require('./configuration');
 const sheets = googleSheets.sheets('v4');
-const formatters = require('../src/scripts/formatters');
 
-function addChangeToDictionary (data) {
+export function addChangeToDictionary (data) {
   const versionista = data.to_version.source_type === 'versionista'
     && data.to_version.source_metadata;
 
@@ -17,9 +16,9 @@ function addChangeToDictionary (data) {
     // Output Date/Time
     formatDate(),
     // Maintainers
-    formatters.formatMaintainers(data.page.maintainers),
+    formatMaintainers(data.page.maintainers),
     // Sites
-    formatters.formatSites(data.page.tags),
+    formatSites(data.page.tags),
     // Page Name
     data.page.title,
     // URL
@@ -48,12 +47,12 @@ function addChangeToDictionary (data) {
 
   return appendRowToSheet(
     row,
-    config.baseConfiguration().GOOGLE_DICTIONARY_SHEET_ID
+    baseConfiguration().GOOGLE_DICTIONARY_SHEET_ID
   )
     .then(() => ({ success: 'appended' }));
 }
 
-function addChangeToImportant (data) {
+export function addChangeToImportant (data) {
   const versionista = data.to_version.source_type === 'versionista'
     && data.to_version.source_metadata;
   const annotation = data.annotation || {};
@@ -68,9 +67,9 @@ function addChangeToImportant (data) {
     // Output Date/Time
     formatDate(),
     // Maintainers
-    formatters.formatMaintainers(data.page.maintainers),
+    formatMaintainers(data.page.maintainers),
     // Sites
-    formatters.formatSites(data.page.tags),
+    formatSites(data.page.tags),
     // Page Name
     data.page.title,
     // URL
@@ -141,7 +140,7 @@ function addChangeToImportant (data) {
 
   return appendRowToSheet(
     row,
-    config.baseConfiguration().GOOGLE_IMPORTANT_CHANGE_SHEET_ID,
+    baseConfiguration().GOOGLE_IMPORTANT_CHANGE_SHEET_ID,
     'A6:AN6'
   )
     .then(() => ({ success: 'appended' }));
@@ -192,7 +191,7 @@ function addAuthentication (requestData) {
     // If tokens expire in 30 seconds or less, refresh them.
     const expirationLeeway = 30000;
     if (!authTokens || Date.now() > authTokens.expiry_date - expirationLeeway) {
-      const configuration = config.baseConfiguration();
+      const configuration = baseConfiguration();
       const clientEmail = configuration.GOOGLE_SERVICE_CLIENT_EMAIL;
       // Replace `\n` in ENV variable with actual line breaks.
       const privateKey = configuration.GOOGLE_SHEETS_PRIVATE_KEY.replace(/\\n/g, '\n');
@@ -229,6 +228,3 @@ function formatDate (date) {
     .replace(/(\d\d)\.\d+/, '$1')
     .replace('Z', ' GMT');
 }
-
-exports.addChangeToDictionary = addChangeToDictionary;
-exports.addChangeToImportant = addChangeToImportant;

--- a/src/components/__tests__/change-view.test.jsx
+++ b/src/components/__tests__/change-view.test.jsx
@@ -3,10 +3,10 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { ApiContext } from '../api-context';
 import ChangeView, { defaultDiffType, diffTypeStorage } from '../change-view/change-view';
-import layeredStorage from '../../scripts/layered-storage';
+import layeredStorage from '../../scripts/layered-storage.js';
 import simplePage from '../../__mocks__/simple-page.json';
-import WebMonitoringDb from '../../services/web-monitoring-db';
-import { diffTypesFor } from '../../constants/diff-types';
+import WebMonitoringDb from '../../services/web-monitoring-db.js';
+import { diffTypesFor } from '../../constants/diff-types.js';
 
 // The mock simply renders a list of props so we can inspect them.
 jest.mock('../diff-view');

--- a/src/components/__tests__/diff-view.test.jsx
+++ b/src/components/__tests__/diff-view.test.jsx
@@ -4,7 +4,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import DiffView from '../diff-view';
 import simplePage from '../../__mocks__/simple-page.json';
 import { ApiContext } from '../api-context';
-import WebMonitoringDb from '../../services/web-monitoring-db';
+import WebMonitoringDb from '../../services/web-monitoring-db.js';
 
 describe('diff-view', () => {
   let mockApi;

--- a/src/components/__tests__/login-form.test.jsx
+++ b/src/components/__tests__/login-form.test.jsx
@@ -2,7 +2,7 @@
 
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import LoginPanel from '../login-form/login-form';
-import WebMonitoringDb from '../../services/web-monitoring-db';
+import WebMonitoringDb from '../../services/web-monitoring-db.js';
 import { ApiContext } from '../api-context';
 
 describe('login-form', () => {

--- a/src/components/__tests__/page-details.test.jsx
+++ b/src/components/__tests__/page-details.test.jsx
@@ -3,7 +3,7 @@ import { render, waitFor, screen } from '@testing-library/react';
 import PageDetails from '../page-details/page-details';
 import simplePage from '../../__mocks__/simple-page.json';
 import { ApiContext } from '../api-context';
-import WebMonitoringDb from '../../services/web-monitoring-db';
+import WebMonitoringDb from '../../services/web-monitoring-db.js';
 
 jest.mock('../change-view/change-view');
 

--- a/src/components/api-context.js
+++ b/src/components/api-context.js
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
-import WebMonitoringApi from '../services/web-monitoring-api';
-import WebMonitoringDb from '../services/web-monitoring-db';
+import WebMonitoringApi from '../services/web-monitoring-api.js';
+import WebMonitoringDb from '../services/web-monitoring-db.js';
 
 export const ApiContext = createContext({
   /** @type {WebMonitoringDb | null} */

--- a/src/components/change-view/change-view.jsx
+++ b/src/components/change-view/change-view.jsx
@@ -14,7 +14,7 @@ import {
   mediaTypeForExtension,
   parseMediaType,
   unknownType
-} from '../../scripts/media-type';
+} from '../../scripts/media-type.js';
 
 import baseStyles from '../../css/base.css';
 import viewStyles from './change-view.css';

--- a/src/components/inline-rendered-diff.jsx
+++ b/src/components/inline-rendered-diff.jsx
@@ -5,7 +5,7 @@ import {
   loadSubresourcesFromWayback,
   compose
 } from '../scripts/html-transforms';
-import { versionUrl } from '../scripts/tools';
+import { versionUrl } from '../scripts/tools.js';
 import SandboxedHtml from './sandboxed-html';
 
 /**

--- a/src/components/page-details/page-details.jsx
+++ b/src/components/page-details/page-details.jsx
@@ -8,7 +8,7 @@ import PageUrlDetails from '../page-url-details/page-url-details';
 import PageTag from '../page-tag/page-tag';
 import StandardTooltip from '../standard-tooltip/standard-tooltip';
 import { describeHttpStatus } from '../../scripts/http-info';
-import { removeNonUserTags } from '../../scripts/tools';
+import { removeNonUserTags } from '../../scripts/tools.js';
 
 import baseStyles from '../../css/base.css';
 import pageStyles from './page-details.css';

--- a/src/components/page-list/page-list.jsx
+++ b/src/components/page-list/page-list.jsx
@@ -8,7 +8,7 @@ import {
   getHttpStatusCategory,
   describeHttpStatus
 } from '../../scripts/http-info';
-import { removeNonUserTags } from '../../scripts/tools';
+import { removeNonUserTags } from '../../scripts/tools.js';
 
 import baseStyles from '../../css/base.css';
 import listStyles from './page-list.css';

--- a/src/components/side-by-side-rendered-diff.jsx
+++ b/src/components/side-by-side-rendered-diff.jsx
@@ -7,7 +7,7 @@ import {
   compose,
   addTargetBlank
 } from '../scripts/html-transforms';
-import { versionUrl } from '../scripts/tools';
+import { versionUrl } from '../scripts/tools.js';
 import SandboxedHtml from './sandboxed-html';
 
 /**

--- a/src/constants/__tests__/diff-types.test.js
+++ b/src/constants/__tests__/diff-types.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 import { diffTypes, diffTypesFor } from '../diff-types';
-import MediaType from '../../scripts/media-type';
+import MediaType from '../../scripts/media-type.js';
 
 describe('diffTypesFor', () => {
   it('accepts a file extension', () => {

--- a/src/constants/diff-types.js
+++ b/src/constants/diff-types.js
@@ -2,7 +2,7 @@ import {
   mediaTypeForExtension,
   parseMediaType,
   unknownType
-} from '../scripts/media-type';
+} from '../scripts/media-type.js';
 
 export const diffTypes = {
   RAW_FROM_CONTENT: {

--- a/src/scripts/__tests__/db-helpers.test.js
+++ b/src/scripts/__tests__/db-helpers.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { formatDateRange } from '../db-helpers';
+import { formatDateRange } from '../db-helpers.js';
 import { DateTime } from 'luxon';
 
 describe('db-helpers', () => {

--- a/src/scripts/__tests__/media-type.test.js
+++ b/src/scripts/__tests__/media-type.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import MediaType, { parseMediaType } from '../media-type';
+import MediaType, { parseMediaType } from '../media-type.js';
 
 describe('MediaType module', () => {
   test('MediaType objects have a mediaType and genericType', () => {

--- a/src/scripts/formatters.js
+++ b/src/scripts/formatters.js
@@ -1,8 +1,8 @@
-/*eslint-env commonjs*/
+export let dateFormatter;
 
 // Intl.DateTimeFormat is available in most engines, but not *everywhere.*
-if (global.Intl && global.Intl.DateTimeFormat) {
-  exports.dateFormatter = new Intl.DateTimeFormat('en-US', {
+if (globalThis.Intl && globalThis.Intl.DateTimeFormat) {
+  dateFormatter = new Intl.DateTimeFormat('en-US', {
     day: 'numeric',
     hour: 'numeric',
     minute: 'numeric',
@@ -16,16 +16,16 @@ else {
   // This follows the same basic API as Intl.DateTimeFormat, but returns a very
   // simple old-school localized date. It won't have perfect formatting, but it
   // works and is minimally complex.
-  exports.dateFormatter = {
+  dateFormatter = {
     format (date) {
       return date.toLocaleString();
     }
   };
 }
 
-exports.formatMaintainers = maintainers => maintainers.map(maintainership => maintainership.name).join(', ');
+export const formatMaintainers = maintainers => maintainers.map(maintainership => maintainership.name).join(', ');
 
-exports.formatSites = tags => {
+export const formatSites = tags => {
   const sitePrefix = 'site:';
   return tags
     .filter(tagging => tagging.name.startsWith(sitePrefix))

--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -1,4 +1,4 @@
-import { versionUrl } from './tools';
+import { versionUrl } from './tools.js';
 
 /**
  * HtmlTransforms are functions that take an HTML Document and modify it in

--- a/src/services/web-monitoring-db.js
+++ b/src/services/web-monitoring-db.js
@@ -1,4 +1,4 @@
-import { formatDateRange } from '../scripts/db-helpers';
+import { formatDateRange } from '../scripts/db-helpers.js';
 const defaultApiUrl = 'https://api.monitoring-staging.envirodatagov.org/';
 const storageLocation = 'WebMonitoringDb.token';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,14 @@
-const autoprefixer = require('autoprefixer');
-const CompressionPlugin = require('compression-webpack-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const path = require('path');
-const zopfli = require('@gfx/zopfli');
+import autoprefixer from 'autoprefixer';
+import CompressionPlugin from 'compression-webpack-plugin';
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+import path from 'path';
+import zopfli from '@gfx/zopfli';
 
 const nodeEnv = process.env.NODE_ENV || 'development';
 const isProduction = nodeEnv.toLocaleLowerCase() === 'production';
-const context = __dirname;
+const context = import.meta.dirname;
 
-module.exports = {
+const config = {
   context,
   mode: isProduction ? 'production' : 'development',
   devtool: isProduction ? 'source-map' : 'inline-source-map',
@@ -19,7 +19,7 @@ module.exports = {
     // TODO: add hashes for production (server needs to be able to handle them)
     // filename: isProduction ? '[name]-[hash].js' : '[name].js',
     filename: '[name].js',
-    path: path.resolve(__dirname, 'dist'),
+    path: path.resolve(import.meta.dirname, 'dist'),
     publicPath: '/',
     sourceMapFilename: 'sourceMaps/[file].map',
   },
@@ -36,9 +36,9 @@ module.exports = {
         test: /\.css$/,
         // Exclude legacy CSS from CSS modules pipeline
         exclude: [
-          path.resolve(__dirname, 'src/css/styles.css'),
-          path.resolve(__dirname, 'src/css/diff.css'),
-          path.resolve(__dirname, 'node_modules')
+          path.resolve(import.meta.dirname, 'src/css/styles.css'),
+          path.resolve(import.meta.dirname, 'src/css/diff.css'),
+          path.resolve(import.meta.dirname, 'node_modules')
         ],
         use: [
           { loader: 'style-loader' },
@@ -75,12 +75,12 @@ module.exports = {
       {
         test: /\.css$/,
         exclude: [
-          path.resolve(__dirname, 'node_modules')
+          path.resolve(import.meta.dirname, 'node_modules')
         ],
         // Only process legacy CSS files
         include: [
-          path.resolve(__dirname, 'src/css/styles.css'),
-          path.resolve(__dirname, 'src/css/diff.css')
+          path.resolve(import.meta.dirname, 'src/css/styles.css'),
+          path.resolve(import.meta.dirname, 'src/css/diff.css')
         ],
         use: [
           {
@@ -136,7 +136,7 @@ module.exports = {
 
 // Production-specific additions
 if (isProduction) {
-  module.exports.plugins.push(
+  config.plugins.push(
     new CompressionPlugin({
       filename: '[path][base].gz[query]',
       test: /\.(js|css|svg|map)$/i,
@@ -149,3 +149,5 @@ if (isProduction) {
     })
   );
 }
+
+export default config;


### PR DESCRIPTION
We previously used ESM syntax in the client-side browser code, but not the server side or configuration code. This is an attempt at switching fully to ESM.

One messy thing is that, in switching to pure ESM, some combination of Webpack or Babel now wants a lot of (but not all?) our imports from `.js` files to include the extension in the import path. That’s more “correct,” but is a little surprising since it’s smart enough to know it can’t quite treat `.jsx` files that way. Also not sure why this isn’t applying to *all* `.js` files.

Probably needs some more work/investigation/cleanup.