### PR TITLE
Add cooldown period for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,14 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: monthly
       time: "10:00"
+    cooldown:
+      default-days: 5
     open-pull-requests-limit: 10


### PR DESCRIPTION
Thinking about the big supply chain issue on Monday and the mess of Luxon patches yesterday (see #1105), I think it's good to have a little bit of a cooldown period for dependencies. It’s a little longer for NPM packages, since they tend to be a little less stable than many other types in my experience.