### PR TITLE
Make sure all parts of React upgrade together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
         patterns:
           - 'eslint'
           - '@eslint/*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
       testinglibrary:
         patterns:
           - '@testing-library/*'


### PR DESCRIPTION
The “react” and “react-dom” packages are both core parts of React and need to be kept in sync, so this updates Dependabot’s configuration to try and do so.