### PR TITLE
Keep Jest subpackage updates in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
         patterns:
           - 'eslint'
           - '@eslint/*'
+      jest:
+        patterns:
+          - 'jest'
+          - 'jest-*'
       react:
         patterns:
           - 'react'


### PR DESCRIPTION
Jest is broken up into a bunch of smaller sub-packages, but they all have cross-dependencies that need to be kept in sync. This makes sure Dependabot groups them.