### PR TITLE
Fix intra-page links to scroll within iframe

### DIFF
--- a/src/scripts/__tests__/html-transforms.test.js
+++ b/src/scripts/__tests__/html-transforms.test.js
@@ -150,9 +150,11 @@ describe('HtmlTransforms module', () => {
     expect(document.getElementById('hash-only').target).toEqual('');
     expect(document.getElementById('external').target).toEqual('_blank');
 
-    // Intra-page links should have onclick handlers for scrolling
+    // Intra-page links should have onclick handlers for smooth scrolling
     expect(document.getElementById('intra-page').getAttribute('onclick')).toContain('scrollIntoView');
+    expect(document.getElementById('intra-page').getAttribute('onclick')).toContain('smooth');
     expect(document.getElementById('hash-only').getAttribute('onclick')).toContain('scrollTo');
+    expect(document.getElementById('hash-only').getAttribute('onclick')).toContain('smooth');
   });
 
   test('addTargetBlank does not add target="_blank" to javascript: links', () => {
@@ -170,5 +172,27 @@ describe('HtmlTransforms module', () => {
     expect(document.getElementById('js-void').target).toEqual('');
     expect(document.getElementById('js-alert').target).toEqual('');
     expect(document.getElementById('external').target).toEqual('_blank');
+  });
+
+  test('addTargetBlank preserves existing onclick handlers on intra-page links', () => {
+    let document = parser.parseFromString(`<!doctype html>
+      <html>
+        <body>
+          <a href='#' onclick='doSomething()' id='existing-onclick'>Has onclick</a>
+          <a href='#section' onclick='doOther()' id='section-onclick'>Section with onclick</a>
+          <a href='#section' id='no-onclick'>No onclick</a>
+        </body>
+      </html>
+      `, 'text/html');
+
+    document = addTargetBlank(document);
+    // Existing onclick handlers should be preserved
+    expect(document.getElementById('existing-onclick').getAttribute('onclick')).toEqual('doSomething()');
+    expect(document.getElementById('section-onclick').getAttribute('onclick')).toEqual('doOther()');
+    // Links with existing onclick should NOT get target="_blank"
+    expect(document.getElementById('existing-onclick').target).toEqual('');
+    expect(document.getElementById('section-onclick').target).toEqual('');
+    // Links without existing onclick should get our scroll handler
+    expect(document.getElementById('no-onclick').getAttribute('onclick')).toContain('scrollIntoView');
   });
 });

--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -116,22 +116,25 @@ export function addTargetBlank (document) {
     const href = node.getAttribute('href') || '';
     if (href.startsWith('#')) {
       // For intra-page links, handle scrolling via JavaScript to avoid issues
-      // with the <base> tag causing navigation to the original site URL
-      const targetId = href.slice(1);
-      if (targetId) {
-        // Anchors can target by id or name attribute
-        // Escape backslashes first, then quotes for JS string context
-        const escapedId = targetId.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-        // Use getElementsByName instead of querySelector to avoid CSS selector injection
-        node.setAttribute('onclick',
-          `event.preventDefault(); (document.getElementById('${escapedId}') || document.getElementsByName('${escapedId}')[0])?.scrollIntoView();`
-        );
-      } 
-      else {
-        // href="#" should scroll to top
-        node.setAttribute('onclick', 'event.preventDefault(); window.scrollTo(0, 0);');
+      // with the <base> tag causing navigation to the original site URL.
+      // Skip if onclick already exists (e.g., <a href="#" onclick="...">)
+      if (!node.getAttribute('onclick')) {
+        const targetId = href.slice(1);
+        if (targetId) {
+          // Anchors can target by id or name attribute
+          // Escape backslashes first, then quotes for JS string context
+          const escapedId = targetId.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+          // Use getElementsByName instead of querySelector to avoid CSS selector injection
+          node.setAttribute('onclick',
+            `event.preventDefault(); (document.getElementById('${escapedId}') || document.getElementsByName('${escapedId}')[0])?.scrollIntoView({ behavior: 'smooth' });`
+          );
+        }
+        else {
+          // href="#" should scroll to top
+          node.setAttribute('onclick', 'event.preventDefault(); window.scrollTo({ top: 0, behavior: \'smooth\' });');
+        }
       }
-    } 
+    }
     else if (!href.startsWith('javascript:')) {
       node.setAttribute('target', '_blank');
     }


### PR DESCRIPTION
Fixes #494

## Summary

Intra-page links (e.g., #section) in the diff view now scroll within the iframe instead of opening new tabs. The original suggestion was to simply skip adding target="_blank" to # links, but this caused a "refused to connect" error because the <base> tag resolves #section to the original site URL (e.g., https://www.epa.gov/page#section), which gets blocked by X-Frame-Options.The fix intercepts clicks on intra-page links and handles scrolling via JavaScript onclick handlers.

## Changes

- src/scripts/html-transforms.js: Modified addTargetBlank() to:
    - Add onclick handlers to #section links that scroll to the target element (by id or name attribute)
    - Add onclick handlers to # links that scroll to top
    - Leave javascript: links unchanged
    - Continue adding target="_blank" to all other links
    - Use getElementsByName() instead of querySelector() to avoid CSS selector injection
    - Escape backslashes before quotes to ensure correct JS string escaping
    -  Added smooth scrolling (src/scripts/html-transforms.js:126-132):                                                                             
    - Added check !node.getAttribute('onclick') before adding our scroll handler                          
   

## Testing

  - Added test case verifying #section and # links don't get target="_blank" and have appropriate onclick handlers
  - Added test case verifying javascript: links don't get target="_blank"
  - Added assertions for smooth scrolling 
  - Added new test addTargetBlank preserves existing onclick handlers on intra-page links