### PR TITLE
Enhance Google Sheets configuration and error handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,18 @@ WEB_MONITORING_DB_URL=https://api.monitoring.envirodatagov.org
 # `WEB_MONITORING_DB_URL`! The API does not allow public users and you set this
 # to `true`, you're gonna have a bad time: most requests will result in errors.
 ALLOW_PUBLIC_VIEW='true'
+
+# Google Sheets integration (optional). When configured, enables the "Add
+# Important Change" and "Add to Dictionary" features in the change view.
+# Requires a Google service account with write access to the sheets below.
+# Follow the first half of this tutorial to set up credentials:
+# http://isd-soft.com/tech_blog/accessing-google-apis-using-service-account-node-js/
+# GOOGLE_SERVICE_CLIENT_EMAIL=example@example-project.iam.gserviceaccount.com
+# GOOGLE_SHEETS_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\nEXAMPLE\n-----END PRIVATE KEY-----\n
+
+# IDs of each Google Sheet used. To determine a sheet's ID, see:
+# https://developers.google.com/sheets/api/guides/concepts#spreadsheet_id
+# Sheet where changes marked as "important" are saved:
+# GOOGLE_IMPORTANT_CHANGE_SHEET_ID=example_sdf8Za7sdft39a_osnzhJBI2dsftasdf
+# Sheet where changes in the "dictionary" (of insignificant changes) are saved:
+# GOOGLE_DICTIONARY_SHEET_ID=example_sdf8Za7sdft39a_osnzhJBI2dsftasdf

--- a/server/configuration.js
+++ b/server/configuration.js
@@ -87,7 +87,7 @@ export function clientConfiguration () {
     return result;
   }, {});
 
-  config.SHOW_ASSIGNED_PAGES = !!(
+  config.GOOGLE_SHEETS_CONFIGURED = !!(
     source.GOOGLE_SERVICE_CLIENT_EMAIL &&
     source.GOOGLE_SHEETS_PRIVATE_KEY
   );

--- a/server/configuration.js
+++ b/server/configuration.js
@@ -5,7 +5,8 @@ const defaultValues = {
 
 const clientFields = [
   'WEB_MONITORING_DB_URL',
-  'ALLOW_PUBLIC_VIEW'
+  'ALLOW_PUBLIC_VIEW',
+  'SHOW_ASSIGNED_PAGES'
 ];
 
 const processEnvironment = Object.assign(
@@ -82,8 +83,15 @@ export function baseConfiguration () {
 export function clientConfiguration () {
   const source = baseConfiguration();
 
-  return clientFields.reduce((result, field) => {
+  const config = clientFields.reduce((result, field) => {
     result[field] = source[field];
     return result;
   }, {});
+
+  config.SHOW_ASSIGNED_PAGES = !!(
+    source.GOOGLE_SERVICE_CLIENT_EMAIL &&
+    source.GOOGLE_SHEETS_PRIVATE_KEY
+  );
+
+  return config;
 }

--- a/server/configuration.js
+++ b/server/configuration.js
@@ -6,7 +6,6 @@ const defaultValues = {
 const clientFields = [
   'WEB_MONITORING_DB_URL',
   'ALLOW_PUBLIC_VIEW',
-  'SHOW_ASSIGNED_PAGES'
 ];
 
 const processEnvironment = Object.assign(

--- a/server/sheet-data.js
+++ b/server/sheet-data.js
@@ -188,10 +188,14 @@ let authClient;
  */
 function addAuthentication (requestData) {
   return new Promise((resolve, reject) => {
+    const configuration = baseConfiguration();
+    if (!configuration.GOOGLE_SERVICE_CLIENT_EMAIL || !configuration.GOOGLE_SHEETS_PRIVATE_KEY) {
+      return reject(new Error('Google Sheets is not configured. Set GOOGLE_SERVICE_CLIENT_EMAIL and GOOGLE_SHEETS_PRIVATE_KEY to enable this feature.'));
+    }
+
     // If tokens expire in 30 seconds or less, refresh them.
     const expirationLeeway = 30000;
     if (!authTokens || Date.now() > authTokens.expiry_date - expirationLeeway) {
-      const configuration = baseConfiguration();
       const clientEmail = configuration.GOOGLE_SERVICE_CLIENT_EMAIL;
       // Replace `\n` in ENV variable with actual line breaks.
       const privateKey = configuration.GOOGLE_SHEETS_PRIVATE_KEY.replace(/\\n/g, '\n');

--- a/src/components/change-view/change-view.jsx
+++ b/src/components/change-view/change-view.jsx
@@ -243,7 +243,7 @@ export default class ChangeView extends Component {
             <i className="fa fa-pencil" aria-hidden="true" />
             <a className="lnk-action" href="#" onClick={this._annotateChange}>Update Record</a>
           </div>
-          {window.webMonitoringConfig.SHOW_ASSIGNED_PAGES && (
+          {window.webMonitoringConfig.GOOGLE_SHEETS_CONFIGURED && (
             <div className={viewStyles.actionsSection}>
               {markSignificant}
               {addToDictionary}

--- a/src/components/change-view/change-view.jsx
+++ b/src/components/change-view/change-view.jsx
@@ -243,10 +243,12 @@ export default class ChangeView extends Component {
             <i className="fa fa-pencil" aria-hidden="true" />
             <a className="lnk-action" href="#" onClick={this._annotateChange}>Update Record</a>
           </div>
-          <div className={viewStyles.actionsSection}>
-            {markSignificant}
-            {addToDictionary}
-          </div>
+          {window.webMonitoringConfig.SHOW_ASSIGNED_PAGES && (
+            <div className={viewStyles.actionsSection}>
+              {markSignificant}
+              {addToDictionary}
+            </div>
+          )}
         </div>
       ),
       (


### PR DESCRIPTION
Closes #212

This pull request cleans up the existing optional Google Sheets integration, which was already in place but had no graceful handling for the unconfigured case; causing confusing server-side errors and silent UI failures for deployments not using Sheets. 

> [!NOTE] 
> Final UI testing unverified: verifying the sheets buttons show/hide correctly requires an authenticated user with annotate permissions, which needs a running web-monitoring-db instance. Had trouble getting a local instance set up. @Mr0grog is it worth getting production credentials to test, or are you aware of any documentation gaps that could be causing local setup issues? (More so a note for future)

**Google Sheets Integration:**

* Added new environment variables in `.env.example` for Google Sheets service account credentials and sheet IDs, along with documentation on how to set them up.
* Updated `server/configuration.js` to detect if Google Sheets is configured and expose a `GOOGLE_SHEETS_CONFIGURED` flag to the client. [[1]](diffhunk://#diff-ee0b400f3f3c446231b93f9c21c1df04c8863bb7a30e886b7a23589268eaa2abL8-R8) [[2]](diffhunk://#diff-ee0b400f3f3c446231b93f9c21c1df04c8863bb7a30e886b7a23589268eaa2abL85-R95)
* Improved error handling in `server/sheet-data.js` to reject operations with a clear error if Google Sheets credentials are missing.

**UI Changes:**

* Updated `ChangeView` component to conditionally display Google Sheets-related actions only when integration is configured.

