### PR TITLE
Require test job to pass before publishing Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,13 @@ workflows:
             branches:
               only:
                 - release
+      - test:
+          filters:
+            branches:
+              only:
+                - release
       - publish_docker:
           requires:
             - build
             - build_docker
+            - test


### PR DESCRIPTION
This pull request updates the CircleCI workflow configuration to ensure that tests are run on the `release` branch before publishing Docker images. The main changes are:

Workflow improvements:

* Added a `test` job that runs only on the `release` branch, ensuring tests are executed before deployment.
* Updated the `publish_docker` job to require the `test` job, enforcing that Docker images are only published if tests pass.