### PR TITLE
Use hardened Docker images for development and release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,11 @@ jobs:
     machine:
       image: ubuntu-2004:202111-02
     steps:
+      # You have to be logged in to download hardened base images (but it can
+      # be a free account).
+      - run:
+          name: Docker Login
+          command: docker login -u $DOCKER_USER -p $DOCKER_PASS
       - checkout
       - run:
           name: Build Image

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,6 +2,8 @@
 
 Web-monitoring-ui is deployed on Kubernetes. Docker image builds are automated via CI on the `release` branch. Deploying to Kubernetes is a manual step managed in [web-monitoring-ops](https://github.com/edgi-govdata-archiving/web-monitoring-ops).
 
+The release image is built from [Docker Hardened Images](https://docs.docker.com/dhi/) (`dhi.io/node`). The CI environment (and any local build host) must be authenticated to `dhi.io` and have access to the `node` hardened image repository for `docker build` to succeed.
+
 The application is decoupled from the other [web monitoring](https://github.com/edgi-govdata-archiving/web-monitoring) components and interacts only with [web-monitoring-db](https://github.com/edgi-govdata-archiving/web-monitoring-db).
 
 ## Environment Variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Baseline image for development/test/build ###
 # We require a lot of extras for building (Python, GCC) because of Node-Zopfli.
-FROM node:22.16.0 as dev
+FROM dhi.io/node:22-debian13-dev as dev
 LABEL maintainer="enviroDGI@gmail.com"
 
 RUN mkdir -p /app
@@ -24,33 +24,31 @@ CMD ["/bin/bash"]
 # should never actually be distributed; it's just an intermediate.
 FROM dev as build
 ENV NODE_ENV=production
+# We need dumb-init to handle Docker's stop signal, but since the final image has no build tools, we have to install it here and copy it over later.
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
 RUN npm run build-production
-
+RUN npm prune --omit=dev
 
 ### Release Image ###
-# It might feel ridiculous to build up all the same things again, but the
-# resulting image is less than half the size!
-FROM node:22.16.0-slim as release
+FROM dhi.io/node:22-debian13 as release
 LABEL maintainer="enviroDGI@gmail.com"
 
-RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
+# WORKDIR creates the directory if it doesn't exist.
+WORKDIR /app
+
+# Copy production artifacts from the build stage.
+COPY --from=build /usr/bin/dumb-init /usr/bin/dumb-init                                                                                
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist                                                                                                       
+COPY --from=build /app/server ./server
+COPY --from=build /app/views ./views    
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/src/scripts/formatters.js ./src/scripts/formatters.js                                                                                             
 
 ENV NODE_ENV=production
 
-RUN mkdir -p /app
-WORKDIR /app
-
-# Copy dependencies only so they can be cached.
-COPY package.json package-lock.json ./
 EXPOSE 3001
-
-# Install deps.
-RUN npm ci --only=production
-
-# Now copy all source.
-COPY . .
-COPY --from=build /app/dist ./dist
 
 # Run server. Use dumb-init because Node does not handle Docker's stop signal.
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["npm", "run", "start"]
+CMD ["node", "server/app.js"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ We need your help! Please read through the [Web Monitoring Project](https://gith
 
 ## Docker
 
-You can also run this project via Docker. To build and run (on port 3001, as in the instructions for running directly above):
+You can also run this project via Docker. The Dockerfile is based on [Docker Hardened Images](https://www.docker.com/products/hardened-images/) (`dhi.io/node`), so you'll need to be authenticated to `dhi.io` and have access to the `node` hardened image before building. See Docker's [hardened images docs](https://docs.docker.com/dhi/) for setup.
+
+To build and run (on port 3001, as in the instructions for running directly above):
 
 ```
 docker build -t envirodgi/ui .
@@ -91,6 +93,8 @@ To run tests via Docker:
 docker build -t envirodgi/ui:dev --target dev .
 docker run envirodgi/ui:dev npm run test
 ```
+
+The release image is a minimal hardened runtime that contains only production artifacts (no shell, no package manager, no source tree). It runs the server directly via `node server/app.js` under `dumb-init`. The `dev` build stage retains the full toolchain (Python, GCC, npm) needed to compile native dependencies like Node-Zopfli and to run tests.
 
 
 ## Releases


### PR DESCRIPTION
This pull request updates the Docker build and deployment process to use Docker Hardened Images (`dhi.io/node`) for improved security and smaller production images. It also clarifies documentation to help users authenticate to the hardened image registry and understand the new image structure. The most important changes are grouped below.

**Docker image and build process updates:**

* Switched all Docker images in the `Dockerfile` from the default Node.js images to Docker Hardened Images (`dhi.io/node`), both for development and production builds. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R3) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R27-R54)
* Refactored the Docker build process so the release image only contains production artifacts (no shell, package manager, or source tree), and runs the server directly with `node server/app.js` under `dumb-init`. The development image retains the full toolchain for compiling native dependencies and running tests.
* Ensured installation and transfer of `dumb-init` from the build image to the release image for proper signal handling in production containers.

**Documentation updates:**

* Updated `README.md` and `DEPLOYMENT.md` to explain the use of Docker Hardened Images, including authentication requirements for `dhi.io` and links to relevant documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L79-R81) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R97-R98) [[3]](diffhunk://#diff-04615394c116398fb5fcb0aa2d880df854202e4c94907dc81cd2647101ad3306R5-R6)
* Clarified in the docs that the release image is minimal and hardened, and described the differences between the dev and release build stages.

These changes improve security, reduce the size of production images, and provide clearer guidance for contributors and deployers.