### PR TITLE
Render raw view of HTML more nicely

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "jest-environment-jsdom": "^30.4.1",
         "lint-staged": "^17.0.5",
         "mini-css-extract-plugin": "^2.10.2",
+        "nock": "^14.0.15",
         "postcss": "^8.5.15",
         "postcss-loader": "^8.2.1",
         "react": "^19.2.6",
@@ -3282,6 +3283,24 @@
         "tslib": "2"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -3299,6 +3318,31 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -7750,6 +7794,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number-object": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
@@ -8968,6 +9019,13 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -9657,6 +9715,21 @@
       "integrity": "sha512-YTzGAJOo/B6hkodeT5SKKHpOhAzjMfkUCCXjLJwjWk2F4/InIg+HbdH9kmT7bKpleDuqLZDTRy2OdNtAj0IVyQ==",
       "dev": true
     },
+    "node_modules/nock": {
+      "version": "14.0.15",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.15.tgz",
+      "integrity": "sha512-S0a47C9pLvcYx/Ugf0H30BVBEcUgMMBDk9VJIDlJ8XGrfH2QDUD4Tgdp45qDIiHttokBG+IbsOtsvIjGR/j3bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mswjs/interceptors": "^0.41.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.0 <20 || >=20.12.1"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -9917,6 +9990,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -10270,6 +10350,16 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-addr": {
@@ -11329,6 +11419,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -14932,6 +15029,20 @@
         }
       }
     },
+    "@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "dev": true,
+      "requires": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      }
+    },
     "@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -14941,6 +15052,28 @@
       "requires": {
         "@tybys/wasm-util": "^0.10.1"
       }
+    },
+    "@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "requires": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -18005,6 +18138,12 @@
       "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true
     },
+    "is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
+    },
     "is-number-object": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
@@ -18903,6 +19042,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -19369,6 +19514,17 @@
       "integrity": "sha512-YTzGAJOo/B6hkodeT5SKKHpOhAzjMfkUCCXjLJwjWk2F4/InIg+HbdH9kmT7bKpleDuqLZDTRy2OdNtAj0IVyQ==",
       "dev": true
     },
+    "nock": {
+      "version": "14.0.15",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.15.tgz",
+      "integrity": "sha512-S0a47C9pLvcYx/Ugf0H30BVBEcUgMMBDk9VJIDlJ8XGrfH2QDUD4Tgdp45qDIiHttokBG+IbsOtsvIjGR/j3bg==",
+      "dev": true,
+      "requires": {
+        "@mswjs/interceptors": "^0.41.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      }
+    },
     "node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -19553,6 +19709,12 @@
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.5"
       }
+    },
+    "outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true
     },
     "own-keys": {
       "version": "1.0.1",
@@ -19784,6 +19946,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -20567,6 +20735,12 @@
         "es-errors": "^1.3.0",
         "internal-slot": "^1.1.0"
       }
+    },
+    "strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "string-argv": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "jest-environment-jsdom": "^30.4.1",
     "lint-staged": "^17.0.5",
     "mini-css-extract-plugin": "^2.10.2",
+    "nock": "^14.0.15",
     "postcss": "^8.5.15",
     "postcss-loader": "^8.2.1",
     "react": "^19.2.6",
@@ -69,7 +70,7 @@
     "setupFilesAfterEnv": [
       "<rootDir>/src/test-setup.js"
     ],
-    "testEnvironment": "jsdom",
+    "testEnvironment": "./src/test-dom-environment.js",
     "watchPathIgnorePatterns": [
       "<rootDir>/node_modules/",
       "<rootDir>/\\..+/"

--- a/src/components/__tests__/change-view.test.jsx
+++ b/src/components/__tests__/change-view.test.jsx
@@ -146,7 +146,7 @@ describe('change-view', () => {
 
       it('falls back to the unknown-type diff types when the media types have no overlap', () => {
         const fromMediaType = 'text/xml';
-        const toMediaType = 'application/pdf';
+        const toMediaType = 'font/woff';
 
         renderBasicChangeView({ fromMediaType, toMediaType });
 

--- a/src/components/__tests__/diff-view.test.jsx
+++ b/src/components/__tests__/diff-view.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
 import DiffView from '../diff-view';
 import simplePage from '../../__mocks__/simple-page.json';
 import { ApiContext } from '../api-context';
@@ -65,5 +66,54 @@ describe('diff-view', () => {
     await waitFor(() => expect(mockApi.getDiff).toHaveBeenCalled());
     await screen.findByText('Hi');
     expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('loads and renders raw HTML in RAW diffs for text/html versions', async () => {
+    let requestedV0 = false;
+    let requestedV1 = false;
+    nock('http://example.com')
+      .get('/version_0_body')
+      .reply(200, () => {
+        requestedV0 = true;
+        return 'Hello version 0!';
+      })
+      .get('/version_1_body')
+      .reply(200, () => {
+        requestedV1 = true;
+        return '<!doctype html><html><body>Hello version 1!</body></html>';
+      });
+
+    const page = {
+      ...simplePage,
+      versions: [
+        {
+          ...simplePage.versions[0],
+          media_type: 'application/pdf',
+          body_url: 'http://example.com/version_0_body',
+        },
+        {
+          ...simplePage.versions[1],
+          media_type: 'text/html',
+          body_url: 'http://example.com/version_1_body',
+        },
+        ...simplePage.versions.slice(2),
+      ],
+    };
+
+    const { container } = render(
+      <ApiContext value={{ api: mockApi }}>
+        <DiffView
+          diffType="RAW_SIDE_BY_SIDE"
+          page={page}
+          a={page.versions[1]}
+          b={page.versions[0]}
+        />
+      </ApiContext>
+    );
+
+    await waitFor(() => expect(container.querySelector(`iframe[src="${page.versions[0].body_url}"]`)).toBeTruthy());
+    await waitFor(() => expect(container.querySelector('iframe[srcdoc]')).toBeTruthy());
+    expect(requestedV0).toBe(false);
+    expect(requestedV1).toBe(true);
   });
 });

--- a/src/components/diff-settings-form.jsx
+++ b/src/components/diff-settings-form.jsx
@@ -1,7 +1,11 @@
 import { PureComponent } from 'react';
 
 // Diff types that we can remove formatting from
-const typesWithFormatting = ['SIDE_BY_SIDE_RENDERED', 'HIGHLIGHTED_RENDERED'];
+const typesWithFormatting = [
+  'SIDE_BY_SIDE_RENDERED',
+  'HIGHLIGHTED_RENDERED',
+  'RAW_SIDE_BY_SIDE',
+];
 
 // Shallow-merge multiple objects
 const mergeObjects = (...objects) => Object.assign({}, ...objects);

--- a/src/components/diff-view.jsx
+++ b/src/components/diff-view.jsx
@@ -12,6 +12,7 @@ import SideBySideRawVersions from './side-by-side-raw-versions';
 import SideBySideFilePreview from './side-by-side-file-preview/side-by-side-file-preview';
 
 import styles from '../css/base.css';
+import { parseMediaType } from '../scripts/media-type';
 
 /**
  * @typedef DiffViewProps
@@ -144,7 +145,7 @@ export default class DiffView extends Component {
     switch (this.props.diffType) {
       case diffTypes.RAW_SIDE_BY_SIDE.value:
         return (
-          <SideBySideRawVersions {...commonProps} />
+          <SideBySideRawVersions {...commonProps} diffSettings={this.props.diffSettings} />
         );
       case diffTypes.RAW_FROM_CONTENT.value:
         return (
@@ -225,10 +226,8 @@ export default class DiffView extends Component {
       );
     }
     else {
-      dataLoad = Promise.all([
-        fetch(a.body_url, { mode: 'cors' }),
-        fetch(b.body_url, { mode: 'cors' })
-      ]);
+      dataLoad = Promise.all([ fetchRawText(a), fetchRawText(b) ])
+        .then(([rawA, rawB]) => ({ rawA, rawB }));
     }
 
     dataLoad
@@ -255,4 +254,21 @@ function specifiesSameDiff (specifierA, specifierB) {
     && specifierA.a.uuid === specifierB.a.uuid
     && specifierA.b.uuid === specifierB.b.uuid
     && specifierA.diffType === specifierB.diffType;
+}
+
+/**
+ * Get the text content of a version if it is a text media type, otherwise
+ * return `null`.
+ * @param {Version} version
+ * @returns {Promise<String|null>}
+ */
+async function fetchRawText (version) {
+  // TODO: should cache this parsed data somewhere so we don't keep re-parsing.
+  const mediaType = parseMediaType(version.media_type);
+  if (mediaType.type !== 'text') {
+    return null;
+  }
+
+  const response = await fetch(version.body_url, { mode: 'cors' });
+  return await response.text();
 }

--- a/src/components/side-by-side-raw-versions.jsx
+++ b/src/components/side-by-side-raw-versions.jsx
@@ -1,5 +1,13 @@
 import { Component } from 'react';
 import SandboxedHtml from './sandboxed-html';
+import {
+  addTargetBlank,
+  compose,
+  loadSubresourcesFromWayback,
+  removeClientRedirect,
+  removeStyleAndScript,
+} from '../scripts/html-transforms';
+import { htmlType, parseMediaType, unknownType } from '../scripts/media-type';
 
 /**
  * @typedef {Object} SideBySideRawVersionsProps
@@ -7,6 +15,7 @@ import SandboxedHtml from './sandboxed-html';
  * @property {Page} page The page this diff pertains to
  * @property {Version} a
  * @property {Version} b
+ * @property {boolean} diffSettings
  */
 
 /**
@@ -20,16 +29,37 @@ export default class SideBySideRawVersions extends Component {
   render () {
     return (
       <div className="side-by-side-render">
-        {renderVersion(this.props.page, this.props.a, this.props.diffData.rawA)}
-        {renderVersion(this.props.page, this.props.b, this.props.diffData.rawB)}
+        {renderVersion(this.props.page, this.props.a, this.props.diffData.rawA, this.props.diffSettings)}
+        {renderVersion(this.props.page, this.props.b, this.props.diffData.rawB, this.props.diffSettings)}
       </div>
     );
   }
 }
 
-function renderVersion (page, version, content) {
-  if (content && /^[\s\n\r]*</.test(content)) {
-    return <SandboxedHtml html={content} baseUrl={page.url} />;
+function renderVersion (page, version, content, settings) {
+  // TODO: should probably cache the parsed media type on version so we don't
+  // keep re-parsing it.
+  let mediaType = null;
+  if (version.media_type) {
+    mediaType = parseMediaType(version.media_type);
+  }
+  else if (content) {
+    mediaType = /^[\s\n\r]*</.test(content) ? htmlType : unknownType;
+  }
+
+  if (content != null && mediaType.equals(htmlType)) {
+    settings ||= {};
+    const baseTransform = compose(
+      settings.removeFormatting && removeStyleAndScript,
+      addTargetBlank,
+      removeClientRedirect,
+      settings.useWaybackResources && loadSubresourcesFromWayback(
+        page,
+        version,
+      ),
+    );
+
+    return <SandboxedHtml html={content} baseUrl={page.url} transform={baseTransform} />;
   }
 
   return <iframe src={version.body_url} />;

--- a/src/constants/diff-types.js
+++ b/src/constants/diff-types.js
@@ -56,10 +56,10 @@ for (let key in diffTypes) {
 // the browser can render inline instead of just triggering a download.
 // Ideally, we want to provide useful diffs for these in the future.
 const diffTypesForInlineRenderableFiles = [
+  diffTypes.RAW_SIDE_BY_SIDE,
   diffTypes.SIDE_BY_SIDE_FILE_PREVIEW,
   diffTypes.RAW_FROM_CONTENT,
   diffTypes.RAW_TO_CONTENT,
-  diffTypes.RAW_SIDE_BY_SIDE,
 ];
 
 const diffTypesByMediaType = {

--- a/src/test-dom-environment.js
+++ b/src/test-dom-environment.js
@@ -1,0 +1,29 @@
+import JsDomEnvironment from 'jest-environment-jsdom';
+import nodeUtil from 'node:util';
+
+
+/**
+ * Patch jest-environment-jsdom with a few customizations.
+ */
+export default class PatchedJsDomEnvironment extends JsDomEnvironment {
+  constructor (...args) {
+    super(...args);
+
+    // Patch fetch-related globals using Node.js's globals. Not technically
+    // spec-compliant, but good enough for our needs.
+    // See: https://github.com/jsdom/jsdom/issues/1724
+    this.global.fetch = fetch;
+    this.global.Headers = Headers;
+    this.global.Request = Request;
+    this.global.Response = Response;
+    this.global.ReadableStream = ReadableStream;
+    this.global.TransformStream = TransformStream;
+
+    // Jest's JSDOM also does not yet implement TextEncoder, which react-router
+    // needs in the test environment.
+    if (!this.global.TextEncoder || !this.global.TextDecoder) {
+      this.global.TextEncoder = nodeUtil.TextEncoder;
+      this.global.TextDecoder = nodeUtil.TextDecoder;
+    }
+  }
+}

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -1,9 +1,1 @@
 import '@testing-library/jest-dom';
-import nodeUtil from 'node:util';
-
-// Workaround for JSDOM not yet implementing TextEncoder, which React-Router
-// needs in the test environment: https://github.com/jsdom/jsdom/issues/2524
-if (!globalThis.TextEncoder || !globalThis.TextDecoder) {
-  globalThis.TextEncoder = nodeUtil.TextEncoder;
-  globalThis.TextDecoder = nodeUtil.TextDecoder;
-}


### PR DESCRIPTION
After #1235, we render HTML in the “raw” view more often, and it turns out it’s kind of broken, and doesn’t look great. Specifically, we had some code to load the raw content of versions if they aren’t being run through a proper diff service, but it wasn’t really wired up right. Not sure what went wrong here, if something got broken in the past or if this was never quite correct.

This solves the issue, so that:
- If the diff being shown has a service, request the diff (same as before).
- If not, just request the raw content and store it in the form the rest of the app is already set up for (replace the object representing diff results with `{ rawA: '<string contents of version A>', rawB: '<string contents of version B>' }`). As an optimization, we only do this for HTML versions, since we only ever do anything useful if it’s HTML, and because the code is expecting a string, which only works with text media types (all that could possibly change in the future!).

I’ve also tweaked the ordering of diffs so that RAW_SIDE_BY_SIDE comes before SIDE_BY_SIDE_FILE_PREVIEW, since it seems like it’s more understandable/relevant to analysts based on their feedback so far.

Finally, this required some more-complicated-than-I-expected support work for testing, since it turns out we don’t currently have anything mocking fetch/HTTP requests!

This is a quick-ish followup to #1235.

@BeckettFrey I’m probably going to try and merge and deploy this before today’s meeting so we can show your work on #1235 off, but if you want to take a look I will try and address any thoughts as a followup PR.

Before: 
<img width="1785" height="1224" alt="Screenshot 2026-06-08 at 3 32 54 PM" src="https://github.com/user-attachments/assets/46005709-1860-4969-b8e7-2bc9a16d909e" />

After: 
<img width="1785" height="1224" alt="Screenshot 2026-06-08 at 3 33 21 PM" src="https://github.com/user-attachments/assets/7230ff73-4040-4072-82f9-7642a3d1529d" />