### PR TITLE
Show a warning for low-quality versions

### DIFF
--- a/src/components/__tests__/change-view.test.jsx
+++ b/src/components/__tests__/change-view.test.jsx
@@ -240,4 +240,34 @@ describe('change-view', () => {
       expect(layeredStorage.getItem(diffTypeStorage)).toBe(newType);
     });
   });
+
+  describe('QualityWarning', () => {
+    it('shows a warning when a version is low quality', () => {
+      render(
+        <ApiContext value={{ api: mockApi }}>
+          <ChangeView
+            page={simplePage}
+            from={{ ...mockChangeFrom, quality: 1 }}
+            to={{ ...mockChangeTo, quality: 0.1 }}
+          />
+        </ApiContext>
+      );
+
+      screen.getByText(/server may have blocked us/i);
+    });
+
+    it('shows nothing when both versions are good quality', () => {
+      render(
+        <ApiContext value={{ api: mockApi }}>
+          <ChangeView
+            page={simplePage}
+            from={{ ...mockChangeFrom, quality: 1 }}
+            to={{ ...mockChangeTo, quality: 1 }}
+          />
+        </ApiContext>
+      );
+
+      expect(() => screen.getByText(/server may have blocked us/i)).toThrow();
+    });
+  });
 });

--- a/src/components/change-view/change-view.css
+++ b/src/components/change-view/change-view.css
@@ -23,3 +23,7 @@
   padding: 0.7em 0.2em;
   flex: 0 0 auto;
 }
+
+.alert {
+  text-align: center;
+}

--- a/src/components/change-view/change-view.jsx
+++ b/src/components/change-view/change-view.jsx
@@ -151,6 +151,7 @@ export default class ChangeView extends Component {
           />
         </div>
         {this.renderVersionSelector(page)}
+        <QualityWarning a={this.props.from} b={this.props.to} />
         <DiffView page={page} diffType={this.state.diffType} a={this.props.from} b={this.props.to}
           diffSettings={this.state.diffSettings}/>
       </div>
@@ -356,6 +357,46 @@ export default class ChangeView extends Component {
           });
         }
       });
+  }
+}
+
+/**
+ * Shows a warning box about low-quality snapshots if either version is
+ * questionable. This is meant to help people better interpret when it was us
+ * vs. the site that was broken.
+ * @param {object} props
+ * @param {Version} props.a
+ * @param {Version} props.b
+ * @returns {import('react').ReactElement | null}
+ */
+function QualityWarning ({ a, b }) {
+  const qualityA = a?.quality ?? 1.0;
+  const qualityB = b?.quality ?? 1.0;
+
+  let message = null;
+  if (qualityA < 1 && qualityB < 1) {
+    message = <>Both versions appear to be bad snapshots.</>;
+  }
+  else if (qualityA < 1) {
+    message = <>The <strong>from version</strong> appears to be a bad snapshot.</>;
+  }
+  else if (qualityB < 1) {
+    message = <>The <strong>to version</strong> appears to be a bad snapshot.</>;
+  }
+
+  if (message) {
+    return (
+      <div
+        className={`${viewStyles.alert} ${baseStyles.alert} ${baseStyles.alertWarning}`}
+        role="alert"
+      >
+        {message} The web server may have blocked us from saving the page, so
+        this view may not represent the page at your chosen point in time.
+      </div>
+    );
+  }
+  else {
+    return null;
   }
 }
 


### PR DESCRIPTION
When a version has a low estimated quality, this shows a warning about the situation so people can better infer whether a page represents an actual error on the site they are analyzing or just an error on our part capturing it. This is the final part of and fixes https://github.com/edgi-govdata-archiving/web-monitoring/issues/192.

<img width="1609" height="1041" alt="Screenshot of yellow warning box above the diff visualization of the versions, that says 'The from version appears to be a bad snapshot. The web server may have blocked us from saving this page, so this view may not represent the page at your chosen point in time.'" src="https://github.com/user-attachments/assets/cd1e65d2-bcc9-4e23-86f6-c7f2056bae29" />
