### PR TITLE
Improve scroll sync between side-by-side versions

### DIFF
--- a/src/components/side-by-side-rendered-diff.jsx
+++ b/src/components/side-by-side-rendered-diff.jsx
@@ -34,10 +34,16 @@ export default class SideBySideRenderedDiff extends Component {
     this._receiveWindowMessage = this._receiveWindowMessage.bind(this);
     this._htmlViewA = null;
     this._htmlViewB = null;
+    this.resetLandmarks();
+  }
+
+  resetLandmarks () {
+    this._landmarks = { a: [], b: [] };
   }
 
   componentDidMount () {
     window.addEventListener('message', this._receiveWindowMessage);
+    this.resetLandmarks();
   }
 
   componentWillUnmount () {
@@ -84,16 +90,24 @@ export default class SideBySideRenderedDiff extends Component {
   }
 
   /**
-   * Handle `message` events sent to this window via `postMessage()`.
-   *
-   * This brokers scroll events between the two pages. When one page scrolls,
-   * it will post a message with scroll position info. We forward that to the
-   * other page so it can update its scroll position to match.
+   * Handle `message` events sent to this window via `postMessage()`. This just
+   * dispatches to the appropriate handler based on the message type.
    * @param {MessageEvent} event
    */
   _receiveWindowMessage (event) {
-    if (!this.props.syncScrolling || event.data.type !== '__wm_scroll') return;
+    if (!this.props.syncScrolling) return;
 
+    const method = this[`_receive${event.data.type}`];
+    if (method) method.call(this, event);
+  }
+
+  /**
+   * Broker scroll events between the two pages. When one page scrolls, it will
+   * post a message with scroll position info. We forward that to the other
+   * page so it can update its scroll position to match.
+   * @param {MessageEvent} event
+   */
+  _receive__wm_scroll (event) {
     const target = event.data.from === 'A' ? this._htmlViewB : this._htmlViewA;
     if (target) {
       target.postMessage({
@@ -105,6 +119,34 @@ export default class SideBySideRenderedDiff extends Component {
       console.error(
         'Could not find target SandboxedHtml to forward scroll command to!'
       );
+    }
+  }
+
+  /**
+   * Find common scroll landmarks between pages and broadcast the common
+   * landmarks back to them.
+   *
+   * When the pages update their list of landmarks (due to DOM mutations,
+   * events, etc.), they post their landmarks via the "__wm_scroll_landmarks"
+   * event. We find the intersection between both page's landmarks and send
+   * each of them that common list. This makes scrolling smoother, since they
+   * can each attempt to only use landmarks that will be present in the other.
+   * @param {MessageEvent} event
+   */
+  _receive__wm_scroll_landmarks (event) {
+    if (!['A', 'B'].includes(event.data.from)) {
+      console.error(`Got landmark update from unknown frame "${event.data.from}"`);
+      return;
+    }
+
+    this._landmarks[event.data.from.toLowerCase()] = event.data.landmarks;
+    if (this._landmarks.a.length && this._landmarks.b.length) {
+      const commonEvent = {
+        type: '__wm_scroll_landmarks_common',
+        landmarks: this._landmarks.a.filter(id => this._landmarks.b.includes(id)),
+      };
+      this._htmlViewA.postMessage(commonEvent);
+      this._htmlViewB.postMessage(commonEvent);
     }
   }
 }

--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -348,7 +348,8 @@ function inPageScrollModule (identifier, appOrigin) {
       type: '__wm_scroll',
       position: { x: window.scrollX, y: window.scrollY },
       landmark: landmarkId,
-      offset: (y - anchorY) / (nextY - anchorY)
+      offset: (y - anchorY) / (nextY - anchorY),
+      windowOffset: y / window.scrollMaxY,
     }, appOrigin);
   });
 
@@ -380,6 +381,9 @@ function inPageScrollModule (identifier, appOrigin) {
           }
         }
         y = anchorY + event.data.offset * (nextY - anchorY);
+      }
+      else {
+        y = event.data.windowOffset * window.scrollMaxY;
       }
 
       __wm_autoScrolling = true;

--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -235,7 +235,7 @@ function injectScriptModule (document, moduleFunction, ...args) {
  * DOM as such. When syncing scrolling in side-by-side views, we use these
  * landmarks to denote the scroll postion (landmark X, offset to landmark X+1).
  * This lets synced scrolling keep related parts of the page side-by-side even
- * when big changes one side have altered their locations.
+ * when big changes on one side have altered their locations.
  *
  * When the pages are live, `inPageScrollModule` (inserted into the pages
  * themselves) finds these landmarks and their positions on screen.
@@ -279,12 +279,12 @@ function markScrollLandmarks (document) {
           usable = false;
           break;
         }
-        characters += textNode.nodeValue.trim().replace(/[\s\n]/g, '');
+        characters += textNode.nodeValue.trim().replace(/[\s\n:_-]/g, '');
       }
       usable = usable && characters.length > minimumText;
     }
     else {
-      characters = e.textContent.trim().replace(/[\s\n]/g, '');
+      characters = e.textContent.trim().replace(/[\s\n:_-]/g, '');
       usable = usable && characters.length > minimumText;
     }
 
@@ -298,6 +298,28 @@ function markScrollLandmarks (document) {
       e.setAttribute('wm-scroll-landmark', `${idBase}-${idIndex}`);
     }
   }
+
+  // Special ARIA landmarks that should be unique on a page.
+  [
+    {
+      id: '::banner::',
+      selector: '[role="banner"], header:not(:is(aside, article, main, nav, section) header)',
+    },
+    {
+      id: '::contentinfo::',
+      selector: '[role="contentinfo"], footer:not(:is(aside, article, main, nav, section) footer)',
+    },
+    {
+      id: '::main::',
+      selector: '[role="main"], main',
+    },
+  ].forEach(({ id, selector }) => {
+    const nodes = document.querySelectorAll(selector);
+    if (nodes.length === 1) {
+      nodes[0].classList.add('wm-scroll-landmark');
+      nodes[0].setAttribute('wm-scroll-landmark', id);
+    }
+  });
 }
 
 function inPageScrollModule (identifier, appOrigin) {

--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -374,6 +374,11 @@ function inPageScrollModule (identifier, appOrigin) {
       __wm_autoScrolling = true;
       window.scrollTo({ left: x, top: y, behavior: 'instant' });
     }
+    else if (event.data.type === '__wm_scroll_landmarks_common') {
+      for (const landmark of __wm_scrollLandmarks) {
+        landmark.usable = event.data.landmarks.includes(landmark.id);
+      }
+    }
   });
 
   function getScrollLandmarks () {
@@ -432,6 +437,12 @@ function inPageScrollModule (identifier, appOrigin) {
     __wm_scrollLandmarks = getScrollLandmarks();
     __wm_scrollIds = new Map(__wm_scrollLandmarks.map(x => [x.id, x]));
     // console.log(`Landmarks ${identifier}:`, __wm_scrollLandmarks);
+
+    window.top.postMessage({
+      from: identifier,
+      type: '__wm_scroll_landmarks',
+      landmarks: __wm_scrollLandmarks.filter(l => l.usable).map(l => l.id),
+    }, appOrigin);
   }
 
   updateScrollLandmarks();

--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -395,6 +395,7 @@ function inPageScrollModule (identifier, appOrigin) {
     // const rootBounds = document.documentElement.getBoundingClientRect();
     const baseX = window.scrollX;
     const baseY = window.scrollY;
+    let lastY = -Infinity;
     const result = Array.from(document.querySelectorAll('[wm-scroll-landmark]'))
       .map(node => {
         const id = parseInt(node.getAttribute('wm-scroll-landmark'), 10);
@@ -408,7 +409,12 @@ function inPageScrollModule (identifier, appOrigin) {
           && bounds.height > 0
           && x + bounds.width > 0
           && y + bounds.height > 0
+          && y > lastY
         );
+
+        if (usable) {
+          lastY = y;
+        }
 
         return {
           id,

--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -253,10 +253,12 @@ function markScrollLandmarks (document) {
   const candidates = [...document.querySelectorAll(`
     h1, h2, h3, h4, h5, h6,
     .h1, .h2, .h3, .h4, .h5, .h6,
-    header,footer,section,article,nav
+    header,footer,section,article,nav,
     .box
   `)];
-  let index = 0;
+  // Don't make a landmark if it doesn't have at least this  many characters.
+  const minimumText = 10;
+  let ids = new Map();
   for (const e of candidates) {
     if (e.matches(':is(.wm-diff *)')) continue;
 
@@ -267,27 +269,33 @@ function markScrollLandmarks (document) {
     // and be usable as a landmark. This lets us use items with complex content
     // like header/footer or nested content like section as landmarks.
     let usable = true;
+    let characters = '';
     const change = e.querySelector('.wm-diff');
     if (change) {
       const texts = document.createNodeIterator(e, NodeFilter.SHOW_TEXT);
-      let characters = 0;
       let textNode = null;
-      while (characters < 30 && (textNode = texts.nextNode())) {
+      while (characters.length < 30 && (textNode = texts.nextNode())) {
         if (textNode.parentElement.matches('.wm-diff,:is(.wm-diff *)')) {
           usable = false;
           break;
         }
-        characters += textNode.nodeValue.trim().replace(/[\s\n]/g, '').length;
+        characters += textNode.nodeValue.trim().replace(/[\s\n]/g, '');
       }
-      usable = usable && characters > 0;
+      usable = usable && characters.length > minimumText;
+    }
+    else {
+      characters = e.textContent.trim().replace(/[\s\n]/g, '');
+      usable = usable && characters.length > minimumText;
     }
 
     if (usable) {
       // This element should be present in some form on both sides, and is
       // usable as a landmark.
       e.classList.add('wm-scroll-landmark');
-      e.setAttribute('wm-scroll-landmark', index);
-      index++;
+      const idBase = characters.slice(0, 20).toLowerCase();
+      const idIndex = (ids.get(idBase) || 0) + 1;
+      ids.set(idBase, idIndex);
+      e.setAttribute('wm-scroll-landmark', `${idBase}-${idIndex}`);
     }
   }
 }
@@ -297,6 +305,7 @@ function inPageScrollModule (identifier, appOrigin) {
   // we can ignore scroll events.
   let __wm_autoScrolling = false;
   let __wm_scrollLandmarks = [];
+  let __wm_scrollIds = new Map();
 
   window.addEventListener('scroll', (e) => {
     // console.log('SCROLL EVENT in frame ${identifier}, auto:', __wm_autoScrolling, e);
@@ -305,51 +314,39 @@ function inPageScrollModule (identifier, appOrigin) {
       return;
     }
 
-    let anchorText = '<start>';
-    let nextText = '<end>';
     const y = window.scrollY;
-    let anchorY = 0;
-    let nextY = window.scrollMaxY;
-    let landmarkId = -1;
-    let nextLandmark = __wm_scrollLandmarks.find(l => l.y > y && l.usable);
-    if (nextLandmark) {
-      nextY = nextLandmark.y;
-      nextText = nextLandmark.text;
-      for (let i = nextLandmark.id - 1; i >= 0; i--) {
-        const landmark = __wm_scrollLandmarks[i];
-        if (landmark.usable) {
-          landmarkId = landmark.id;
-          anchorY = landmark.y;
-          anchorText = landmark.text;
+    let anchorMark = null;
+    let nextMark = null;
+    for (const mark of __wm_scrollLandmarks) {
+      if (mark.usable) {
+        if (mark.y > y) {
+          nextMark = mark;
           break;
         }
-      }
-    }
-    else if (__wm_scrollLandmarks.length) {
-      for (let i = __wm_scrollLandmarks.length - 1; i >= 0; i--) {
-        const landmark = __wm_scrollLandmarks[i];
-        if (landmark.usable) {
-          landmarkId = landmark.id;
-          anchorY = landmark.y;
-          anchorText = landmark.text;
-          break;
+        else {
+          anchorMark = mark;
         }
       }
     }
 
+    const maxY = window.scrollMaxY;
+    const anchorY = anchorMark?.y ?? 0;
+    const nextY = nextMark?.y ?? maxY;
+
     // Need some better debug tooling.
     // eslint-disable-next-line no-constant-condition
     if (false) {
-      console.log(`SCROLL CALC: anchorY=${anchorY}, y=${y}, nextY=${nextY} (anchor: "${anchorText}", next: "${nextText}")`, __wm_scrollLandmarks);
+      console.log(`SCROLL CALC: anchorY=${anchorY}, y=${y}, nextY=${nextY} (anchor: "${anchorMark?.id || '<start>'}", next: "${nextMark?.id ?? '<end>'}")`, __wm_scrollLandmarks);
     }
 
     window.top.postMessage({
       from: identifier,
       type: '__wm_scroll',
-      position: { x: window.scrollX, y: window.scrollY },
-      landmark: landmarkId,
+      position: { x: window.scrollX, y },
+      anchorMark: anchorMark?.id ?? '',
+      nextMark: nextMark?.id ?? '',
       offset: (y - anchorY) / (nextY - anchorY),
-      windowOffset: y / window.scrollMaxY,
+      windowOffset: y / maxY,
     }, appOrigin);
   });
 
@@ -359,31 +356,19 @@ function inPageScrollModule (identifier, appOrigin) {
       let x = event.data.position.x;
       let y = event.data.position.y;
 
-      let useLandmarks = true;
-      let anchorY = 0;
-      if (event.data.landmark > -1) {
-        const landmark = __wm_scrollLandmarks[event.data.landmark];
-        if (landmark) {
-          anchorY = landmark.y;
-        }
-        else {
-          useLandmarks = false;
-          console.warn(`Could not find scroll landmark in ${identifier}, falling back to literal position`);
-        }
-      }
-      if (useLandmarks) {
-        let nextY = window.scrollMaxY;
-        for (let i = event.data.landmark + 1; i < __wm_scrollLandmarks.length; i++) {
-          const nextLandmark = __wm_scrollLandmarks[i];
-          if (nextLandmark.usable) {
-            nextY = nextLandmark.y;
-            break;
-          }
-        }
-        y = anchorY + event.data.offset * (nextY - anchorY);
+      let anchorMark = __wm_scrollIds.get(event.data.anchorMark);
+      let nextMark = __wm_scrollIds.get(event.data.nextMark);
+      let landmarkError = (event.data.anchorMark && !anchorMark?.usable)
+        || (event.data.nextMark && !nextMark?.usable);
+
+      if (landmarkError) {
+        console.warn(`Could not find scroll landmark in ${identifier}, falling back to global offset`);
+        y = event.data.windowOffset * window.scrollMaxY;
       }
       else {
-        y = event.data.windowOffset * window.scrollMaxY;
+        let anchorY = anchorMark?.y ?? 0;
+        let nextY = nextMark?.y ?? window.scrollMaxY;
+        y = anchorY + event.data.offset * (nextY - anchorY);
       }
 
       __wm_autoScrolling = true;
@@ -396,11 +381,16 @@ function inPageScrollModule (identifier, appOrigin) {
     const baseX = window.scrollX;
     const baseY = window.scrollY;
     let lastY = -Infinity;
+    let lastIndex = -1;
     const result = Array.from(document.querySelectorAll('[wm-scroll-landmark]'))
       .map(node => {
-        const id = parseInt(node.getAttribute('wm-scroll-landmark'), 10);
-        if (isNaN(id)) return null;
+        const id = node.getAttribute('wm-scroll-landmark')?.trim();
+        if (!id) {
+          console.error(`Scroll landmark in ${identifier} had invalid ID`);
+          return null;
+        }
 
+        const index = ++lastIndex;
         const bounds = node.getBoundingClientRect();
         const x = bounds.left + baseX;
         const y = bounds.top + baseY;
@@ -418,16 +408,14 @@ function inPageScrollModule (identifier, appOrigin) {
 
         return {
           id,
+          index,
           x,
           y,
           usable,
-          text: node.textContent.trim().replace(/[\s\n]+/g, ' '),
+          text: node.textContent.trim().replace(/[\s\n]+/g, ' ').slice(0, 50),
         };
       })
       .filter(Boolean);
-    if (result.some((x, index) => x.id !== index)) {
-      console.error(`SCROLL LANDMARK IDS OUT OF SYNC in ${identifier}:`, result);
-    }
     return result;
   }
 
@@ -442,6 +430,8 @@ function inPageScrollModule (identifier, appOrigin) {
     }
     lastUpdate = now;
     __wm_scrollLandmarks = getScrollLandmarks();
+    __wm_scrollIds = new Map(__wm_scrollLandmarks.map(x => [x.id, x]));
+    // console.log(`Landmarks ${identifier}:`, __wm_scrollLandmarks);
   }
 
   updateScrollLandmarks();

--- a/src/scripts/html-transforms.js
+++ b/src/scripts/html-transforms.js
@@ -257,7 +257,7 @@ function markScrollLandmarks (document) {
     .box
   `)];
   // Don't make a landmark if it doesn't have at least this  many characters.
-  const minimumText = 10;
+  const minimumText = 8;
   let ids = new Map();
   for (const e of candidates) {
     if (e.matches(':is(.wm-diff *)')) continue;


### PR DESCRIPTION
The scroll syncing between views in the side-by-side rendered diff has always been a little unstable because it doesn’t really have enough info from the diff itself to do the right thing (should fix that, too, but it’s a whole other ball of wax).

However, we could still do much better! The changes here make it much smoother and more accurate on a lot of otherwise messy pages:
1. Pass better fallback information for times when matching landmarks between the two frames can’t be found.
2. Only use landmarks that are in visual sequence (they were previously used in DOM order, but there are a lot of pages where that doesn’t wind up matching the visual order, and where the other frame from where you are scrolling goes in all different directions because of it).
3. Use landmark IDs based on the text of the landmark, rather than indexes into a list. When two versions have disjoint sets of landmarks this makes things much more stable. It also helps a lot when JavaScript on a page adds or removes landmarks (surprisingly more common than I’d expected!).
4. Provide a means for the two frames to share and find the common intersection between their list of landmarks. This helps make sure we rarely wind up in a situation where we have to use the fallback scrolling from (1) when there is a significant difference between the landmarks in the two frames.